### PR TITLE
fix jq error when cidr is a Ref

### DIFF
--- a/lib/json_rules/cidr_rules.rb
+++ b/lib/json_rules/cidr_rules.rb
@@ -46,8 +46,15 @@ non_32_cidr_jq_expression = <<END
  else (
         if (.Properties.SecurityGroupIngress|type == "array")
         then (
-               select(.Properties.SecurityGroupIngress[]|select(.CidrIp|endswith("/32")|not))
-             )
+               select(.Properties.SecurityGroupIngress[]|
+                      if (.CidrIp|type == "string")
+                      then (
+                          select(.CidrIp|endswith("/32")|not)
+                      )
+                      else empty
+                      end
+               )
+        )
         else empty
         end
       )


### PR DESCRIPTION
when CidrIp is an object/array (a "Ref" for example ) jq would fail with:
```
jq: error (at test.template:23): endswith() requires string inputs
```
added an additional check to see if it was a string, if not return empty.

tested against this snippet:
```json
{
    "Resources": {
        "CfnNagFail" : {
          "Type" : "AWS::EC2::SecurityGroup",
          "Properties": {
                "SecurityGroupIngress": [
                    {
                        "CidrIp": { "Ref": "TestRef" } 
                    }
                ]
            }
        }
    }
}
```
