### PR TITLE
Checks for empty rule directory before trying to eval rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.gem
+spec/aws_sample_templates

--- a/lib/cfn_nag.rb
+++ b/lib/cfn_nag.rb
@@ -206,9 +206,11 @@ class CfnNag
     rule_directories.each do |rule_directory|
       rules = Dir[File.join(rule_directory, '*.rb')].sort
 
-      rules.each do |rule_file|
-        @input_json = input_json
-        eval IO.read(rule_file)
+      if rules.length > 0
+        rules.each do |rule_file|
+          @input_json = input_json
+          eval IO.read(rule_file)
+        end
       end
     end
   end


### PR DESCRIPTION
This makes it so if a custom rule directory is specified, but no rules currently exist in the directory, it won't crash. This specifically helps the cfn_nag_server project, where a custom_rules directory is created, but by default is empty.

Also adds .gitignore file to ignore files generated from testing.