### PR TITLE
adds support for loading a profile using the format for cfn_nag_rule

### DIFF
--- a/lib/cfn-nag/profile_loader.rb
+++ b/lib/cfn-nag/profile_loader.rb
@@ -16,10 +16,14 @@ class ProfileLoader
 
     profile_definition.each_line do |line|
       rule_id = line.chomp
-      if @rules_registry.by_id(rule_id) == nil
-        raise "#{rule_id} is not a legal rule identifier from: #{@rules_registry.rules.map { |rule| rule.id }}"
-      else
-        new_profile.add_rule rule_id
+      rule_line_match = /^([a-zA-Z]*?[0-9]+)\s*(.*)/.match(rule_id)
+      if !rule_line_match.nil?
+        rule_id = rule_line_match.captures.first
+        if @rules_registry.by_id(rule_id) == nil
+          raise "#{rule_id} is not a legal rule identifier from: #{@rules_registry.rules.map { |rule| rule.id }}"
+        else
+          new_profile.add_rule rule_id
+        end
       end
     end
     new_profile

--- a/spec/profile_loader_spec.rb
+++ b/spec/profile_loader_spec.rb
@@ -1,11 +1,23 @@
 require 'spec_helper'
 require 'cfn-nag/profile_loader'
 require 'cfn-nag/rule_registry'
+require 'cfn-nag/result_view/rules_view'
 require 'set'
 
 describe ProfileLoader do
 
   describe '#load' do
+    before(:all) do
+      @rule_registry = RuleRegistry.new
+
+      @rule_registry.definition(id: 'id1',
+                                type: Violation::WARNING,
+                                message: 'fakeo')
+      @rule_registry.definition(id: 'id2',
+                                type: Violation::WARNING,
+                                message: 'fakeo2')
+    end
+
     context 'empty profile' do
 
       it 'should raise an error' do
@@ -17,27 +29,34 @@ describe ProfileLoader do
     end
 
     context 'non-existent rule number' do
-      before(:all) do
-        @rule_registry = RuleRegistry.new
-
-        @rule_registry.definition(id: 'id1',
-                                  type: Violation::WARNING,
-                                  message: 'fakeo')
-        @rule_registry.definition(id: 'id2',
-                                  type: Violation::WARNING,
-                                  message: 'fakeo2')
-      end
 
       it 'should raise an error' do
 
         expect {
-          ProfileLoader.new(@rule_registry).load profile_definition: 'FAKEID'
+          ProfileLoader.new(@rule_registry).load profile_definition: 'FAKEID1'
         }.to raise_error #'FAKEID is not a legal rule identifier'
       end
 
       it 'should return a profile object' do
 
         new_profile = ProfileLoader.new(@rule_registry).load profile_definition: "id1\nid2"
+        expect(new_profile.rule_ids).to eq Set.new %w(id1 id2)
+      end
+    end
+
+    context 'load profile using rule dump format' do
+      before(:all) do
+        @rule_view_output = <<END
+WARNING VIOLATIONS:
+
+FAILING VIOLATIONS:
+id1 fakeo
+id2 fakeo2
+END
+      end
+
+      it 'should parse the rule dump format' do
+        new_profile = ProfileLoader.new(@rule_registry).load profile_definition: @rule_view_output
         expect(new_profile.rule_ids).to eq Set.new %w(id1 id2)
       end
     end


### PR DESCRIPTION
When I tried to filter out rules I ran `cfn_nag_rules > .cfn_nag` then tired to run `cfn_nag_scan -p .cfn_nag_profile --input-path output/`  but that failed and then worked out the profile only needed the rule Id but to make the profile self documenting I added support for a profile in the same format produced by the cfn_nag_rules.

This PR adds support for commenting out rules like
```
WARNING VIOLATIONS:
W1 Specifying credentials in the template itself is probably not the safest thing
#W2 Security Groups found with cidr open to world on ingress.  This should never be true on instance.  Permissible on ELB

FAILING VIOLATIONS:
F1 EBS volume should have server-side encryption enabled
#F2 IAM role should not allow * action on its trust policy
F3 IAM role should not allow * action on its permissions policy
```
basically means this filters out rules W2 and F2

I've added a RSpec to testing this new behavior