### PR TITLE
Add initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:alpine
+
+LABEL maintainer="steyn@oblcc.com"
+LABEL name="cfn-nag"
+LABEL version="0.3.4"
+
+RUN gem install cfn-nag -v "0.3.4" && gem cleanup
+
+CMD ["cfn_nag"]


### PR DESCRIPTION
For development/run purposes it would be useful to have cfn_nag in a Docker container. This is the first step, automated build instructions can be added later.