### PR TITLE
Fixed operand based on rule intent

### DIFF
--- a/lib/cfn-nag/custom_rules/LambdaPermissionInvokeFunctionActionRule.rb
+++ b/lib/cfn-nag/custom_rules/LambdaPermissionInvokeFunctionActionRule.rb
@@ -16,7 +16,7 @@ class LambdaPermissionInvokeFunctionActionRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_lambdas = cfn_model.resources_by_type('AWS::Lambda::Permission').reject do |lambda_permission|
-      lambda_permission.action == 'lambda:InvokeFunction'
+      lambda_permission.action != 'lambda:InvokeFunction'
     end
 
     violating_lambdas.map(&:logical_resource_id)


### PR DESCRIPTION
Should ensure permissions other than invokeFunction are not present as opposed to warning if invokeFunction is present.

Resolves #127 