### PR TITLE
Add option to ignore rules globally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Failures count: 0
 Warnings count: 0
 ```
 
+Alternatively, if you have existing Cloudformation templates for which you would like to suppress warnings. 
+Edit ignore.yml in the custom_rule folder.
+Add the Ids of any rules you want to globally suppress to this file
+
+Eg:
+
+```yaml
+RulesToSuppress:
+  - id: F18
+    reason: We allow this policy
+  - id: F1000
+    reason: This rule is not valid for the environment we are deploying to.
+```
+
 # Development
 
 ## New Rules

--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary       = 'cfn-nag'
   s.description   = 'Auditing tool for CloudFormation templates'
   s.homepage      = 'https://github.com/stelligent/cfn_nag'
-  s.files         = FileList['lib/**/*.rb']
+  s.files         = FileList['lib/**/*.rb', 'lib/**/*.yml']
 
   s.require_paths << 'lib'
 

--- a/lib/cfn-nag/custom_rules/ignore.yml
+++ b/lib/cfn-nag/custom_rules/ignore.yml
@@ -1,0 +1,5 @@
+# uncomment below to suppress a rule for all files checked.
+#RulesToSuppress:
+#  - id: W3
+#    reason: example reason to suppress a rule
+  

--- a/spec/profile_loader_spec.rb
+++ b/spec/profile_loader_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'cfn-nag/violation'
 require 'cfn-nag/profile_loader'
 require 'cfn-nag/rule_registry'
 require 'cfn-nag/result_view/rules_view'


### PR DESCRIPTION
I wanted to be able to suppress custom rules that aren't relevant in the environment they are being deployed to without modifying a large amount of cloud formation templates.

* Modified custom_rule_loader.rb to look for a file that contains rule Ids to ignore globally
* Added template ignore.yml in the custom_rules folder
* Updated the gemspec to copy yaml files
* Update the ReadMe to detail the option to use the ignore.yml file