### PR TITLE
Re-enable rubocop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.4.6-browsers
+      - image: circleci/ruby:2.5.5-browsers
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
           command: bundle exec rspec --color --require spec_helper spec
   publish:
     docker:
-      - image: circleci/ruby:2.4.6-browsers
+      - image: circleci/ruby:2.5.5-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.2.9-browsers
+      - image: circleci/ruby:2.4.6-browsers
     steps:
       - checkout
       - run:
@@ -13,13 +13,13 @@ jobs:
           command: bundle check || bundle install
       - run:
           name: Rubocop lint
-          command: bundle exec rubocop -D || echo Looks like you failed a lint
+          command: bundle exec rubocop -D
       - run:
           name: Rspec tests
           command: bundle exec rspec --color --require spec_helper spec
   publish:
     docker:
-      - image: circleci/ruby:2.2.9-browsers
+      - image: circleci/ruby:2.4.6-browsers
     steps:
       - checkout
       - run:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - 'spec/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,34 @@
 AllCops:
-  TargetRubyVersion: 2.2
-Layout/IndentHeredoc:
+  TargetRubyVersion: 2.4
+  Exclude:
+    - 'spec/**/*'
+
+Style/Documentation:
   Enabled: false
 
-# not a bad notion except when you are actually trying to select things that are not(something)
-Style/InverseMethods:
+Metrics/LineLength:
   Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/ClassLength:
+  Enabled: false
+
+Security/Eval:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 16
+
+Lint/RescueException:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Metrics/BlockLength:
+  Max: 50

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ For more background on the tool, please see:
 [Finding Security Problems Early in the Development Process of a CloudFormation Template with "cfn-nag"](https://stelligent.com/2016/04/07/finding-security-problems-early-in-the-development-process-of-a-cloudformation-template-with-cfn-nag/)
 
 # Installation
-Presuming Ruby 2.2.x is installed, installation is just a matter of:
+Presuming Ruby 2.4.x or 2.5.x is installed, installation is just a matter of:
 
     gem install cfn-nag
-    
+
 # Pipeline
 To run `cfn_nag` as an action in CodePipeline, you can deploy via the [AWS Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:923120264911:applications~cfn-nag-pipeline).
 
@@ -142,7 +142,7 @@ be flagged if the cidr is parameterized and the 0.0.0.0/0 is passed in at deploy
 To allow for checking parameter values, a user can specify the parameter values in a JSON file passed on the command line
 to both `cfn_nag` and `cfn_nag_scan` with the `--parameter-values-path=<filename/uri>` flag.  
 
-The format of the JSON is a single key "Parameters" whose value is a dictionary with each key/value pair mapping to 
+The format of the JSON is a single key "Parameters" whose value is a dictionary with each key/value pair mapping to
 the Parameters like such:
 
 ```json
@@ -156,7 +156,7 @@ the Parameters like such:
 will fill in "0.0.0.0/0" to the following Parameter:
 
 ```yaml
-Parameters: 
+Parameters:
   Cidr:
     Type: String
 ```

--- a/bin/cfn_nag
+++ b/bin/cfn_nag
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'trollop'
 require 'cfn-nag'
 require 'logging'
@@ -49,9 +51,7 @@ end
 CfnNag.configure_logging(opts)
 
 profile_definition = nil
-unless opts[:profile_path].nil?
-  profile_definition = IO.read(opts[:profile_path])
-end
+profile_definition = IO.read(opts[:profile_path]) unless opts[:profile_path].nil?
 
 parameter_values_string = nil
 unless opts[:parameter_values_path].nil?

--- a/bin/cfn_nag_rules
+++ b/bin/cfn_nag_rules
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'trollop'
 require 'cfn-nag'
 require 'rubygems/specification'
@@ -15,9 +17,7 @@ opts = Trollop.options do
 end
 
 profile_definition = nil
-unless opts[:profile_path].nil?
-  profile_definition = IO.read(opts[:profile_path])
-end
+profile_definition = IO.read(opts[:profile_path]) unless opts[:profile_path].nil?
 
 rule_dumper = CfnNagRuleDumper.new(profile_definition: profile_definition,
                                    rule_directory: opts[:rule_directory])

--- a/bin/cfn_nag_scan
+++ b/bin/cfn_nag_scan
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'trollop'
 require 'cfn-nag'
 require 'logging'
@@ -66,9 +68,7 @@ end
 CfnNag.configure_logging(opts)
 
 profile_definition = nil
-unless opts[:profile_path].nil?
-  profile_definition = IO.read(opts[:profile_path])
-end
+profile_definition = IO.read(opts[:profile_path]) unless opts[:profile_path].nil?
 
 cfn_nag = CfnNag.new(profile_definition: profile_definition,
                      rule_directory: opts[:rule_directory],

--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.require_paths << 'lib'
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rubocop')

--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -1,4 +1,4 @@
-require 'rake'
+# frozen_string_literal: true
 
 Gem::Specification.new do |s|
   s.name          = 'cfn-nag'
@@ -10,11 +10,11 @@ Gem::Specification.new do |s|
   s.summary       = 'cfn-nag'
   s.description   = 'Auditing tool for CloudFormation templates'
   s.homepage      = 'https://github.com/stelligent/cfn_nag'
-  s.files         = FileList['lib/**/*.rb']
+  s.files         = Dir.glob('lib/**/*.rb')
 
   s.require_paths << 'lib'
 
-  s.required_ruby_version = '~> 2.2'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rubocop')

--- a/lib/cfn-nag.rb
+++ b/lib/cfn-nag.rb
@@ -1,5 +1,5 @@
-# rubocop:disable Naming/FileName
+# frozen_string_literal: true
+
 require 'cfn-nag/cfn_nag'
 require 'cfn-nag/violation'
 require 'cfn-nag/rule_dumper'
-# rubocop:enable Naming/FileName

--- a/lib/cfn-nag/cfn_nag.rb
+++ b/lib/cfn-nag/cfn_nag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'custom_rule_loader'
 require_relative 'rule_registry'
 require_relative 'profile_loader'
@@ -31,10 +33,10 @@ class CfnNag
   def audit_aggregate_across_files_and_render_results(input_path:,
                                                       output_format: 'txt',
                                                       parameter_values_path: nil,
-                                                      template_pattern:  '..*\.json|..*\.yaml|..*\.yml|..*\.template')
+                                                      template_pattern: '..*\.json|..*\.yaml|..*\.yml|..*\.template')
     aggregate_results = audit_aggregate_across_files input_path: input_path,
                                                      parameter_values_path: parameter_values_path,
-                                                     template_pattern:  template_pattern
+                                                     template_pattern: template_pattern
 
     render_results(aggregate_results: aggregate_results,
                    output_format: output_format)
@@ -44,14 +46,12 @@ class CfnNag
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
-
   ##
   # Given a file or directory path, return aggregate results
   #
   def audit_aggregate_across_files(input_path:,
                                    parameter_values_path: nil,
-                                   template_pattern:  '..*\.json|..*\.yaml|..*\.yml|..*\.template')
+                                   template_pattern: '..*\.json|..*\.yaml|..*\.yml|..*\.template')
     parameter_values_string = parameter_values_path.nil? ? nil : IO.read(parameter_values_path)
     templates = TemplateDiscovery.new.discover_templates(input_json_path: input_path,
                                                          template_pattern: template_pattern)
@@ -65,9 +65,6 @@ class CfnNag
     end
     aggregate_results
   end
-  # rubocop:enable Metrics/MethodLength
-
-  # rubocop:disable Metrics/MethodLength
 
   ##
   # Given cloudformation json/yml, run all the rules against it
@@ -77,6 +74,7 @@ class CfnNag
   #
   # Return a hash with failure count
   #
+  # rubocop:disable Metrics/MethodLength
   def audit(cloudformation_string:, parameter_values_string: nil)
     violations = []
     cfn_model = CfnParser.new.parse cloudformation_string,
@@ -85,16 +83,16 @@ class CfnNag
     violations = filter_violations_by_profile violations
     { failure_count: Violation.count_failures(violations),
       violations: violations }
-  rescue Psych::SyntaxError, ParserError => parser_error
+  rescue Psych::SyntaxError, ParserError => e
     violations << Violation.new(id: 'FATAL',
                                 type: Violation::FAILING_VIOLATION,
-                                message: parser_error.to_s)
+                                message: e.to_s)
     { failure_count: Violation.count_failures(violations),
       violations: violations }
   rescue JSON::ParserError => json_parameters_error
     violations << Violation.new(id: 'FATAL',
                                 type: Violation::FAILING_VIOLATION,
-                                message: "JSON Parameter values parse error: #{json_parameters_error.to_s}")
+                                message: "JSON Parameter values parse error: #{json_parameters_error}")
     {
       failure_count: Violation.count_failures(violations),
       violations: violations

--- a/lib/cfn-nag/custom_rules/.rubocop.yml
+++ b/lib/cfn-nag/custom_rules/.rubocop.yml
@@ -1,4 +1,0 @@
-Naming/FileName:
-  Enabled: false
-LineLength:
-  Max: 120

--- a/lib/cfn-nag/custom_rules/CloudFormationAuthenticationRule.rb
+++ b/lib/cfn-nag/custom_rules/CloudFormationAuthenticationRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -17,15 +19,12 @@ class CloudFormationAuthenticationRule < BaseRule
   def audit_impl(cfn_model)
     logical_resource_ids = []
     cfn_model.raw_model['Resources'].each do |resource_name, resource|
-      unless resource['Metadata'].nil?
-        unless resource['Metadata']['AWS::CloudFormation::Authentication'].nil?
+      next if resource['Metadata'].nil?
+      next if resource['Metadata']['AWS::CloudFormation::Authentication'].nil?
 
-          resource['Metadata']['AWS::CloudFormation::Authentication'].each do |auth_name, auth|
-            if potentially_sensitive_credentials? auth
-              logical_resource_ids << resource_name
-            end
-          end
-
+      resource['Metadata']['AWS::CloudFormation::Authentication'].each do |_auth_name, auth|
+        if potentially_sensitive_credentials? auth
+          logical_resource_ids << resource_name
         end
       end
     end

--- a/lib/cfn-nag/custom_rules/CloudFrontDistributionAccessLoggingRule.rb
+++ b/lib/cfn-nag/custom_rules/CloudFrontDistributionAccessLoggingRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/EFSFileSystemEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/EFSFileSystemEncryptedRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/EbsVolumeHasSseRule.rb
+++ b/lib/cfn-nag/custom_rules/EbsVolumeHasSseRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/ElastiCacheReplicationGroupAtRestEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/ElastiCacheReplicationGroupAtRestEncryptionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/ElastiCacheReplicationGroupTransitEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/ElastiCacheReplicationGroupTransitEncryptionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerAccessLoggingRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerAccessLoggingRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/IamManagedPolicyNotActionRule.rb
+++ b/lib/cfn-nag/custom_rules/IamManagedPolicyNotActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamManagedPolicyNotActionRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::ManagedPolicy')
-                                  .select do |policy|
-      !policy.policy_document.allows_not_action.empty?
+                                  .reject do |policy|
+      policy.policy_document.allows_not_action.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamManagedPolicyNotResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamManagedPolicyNotResourceRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamManagedPolicyNotResourceRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::ManagedPolicy')
-                                  .select do |policy|
-      !policy.policy_document.allows_not_resource.empty?
+                                  .reject do |policy|
+      policy.policy_document.allows_not_resource.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamManagedPolicyWildcardActionRule.rb
+++ b/lib/cfn-nag/custom_rules/IamManagedPolicyWildcardActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamManagedPolicyWildcardActionRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::ManagedPolicy')
-                                  .select do |policy|
-      !policy.policy_document.wildcard_allowed_actions.empty?
+                                  .reject do |policy|
+      policy.policy_document.wildcard_allowed_actions.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamManagedPolicyWildcardResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamManagedPolicyWildcardResourceRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamManagedPolicyWildcardResourceRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::ManagedPolicy')
-                                  .select do |policy|
-      !policy.policy_document.wildcard_allowed_resources.empty?
+                                  .reject do |policy|
+      policy.policy_document.wildcard_allowed_resources.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamPolicyNotActionRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyNotActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamPolicyNotActionRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy')
-                                  .select do |policy|
-      !policy.policy_document.allows_not_action.empty?
+                                  .reject do |policy|
+      policy.policy_document.allows_not_action.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamPolicyNotResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyNotResourceRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -16,8 +18,8 @@ class IamPolicyNotResourceRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy')
-                                  .select do |policy|
-      !policy.policy_document.allows_not_resource.empty?
+                                  .reject do |policy|
+      policy.policy_document.allows_not_resource.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamPolicyWildcardActionRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyWildcardActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class IamPolicyWildcardActionRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy').select do |policy|
-      !policy.policy_document.wildcard_allowed_actions.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy').reject do |policy|
+      policy.policy_document.wildcard_allowed_actions.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamPolicyWildcardResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyWildcardResourceRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class IamPolicyWildcardResourceRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy').select do |policy|
-      !policy.policy_document.wildcard_allowed_resources.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::IAM::Policy').reject do |policy|
+      policy.policy_document.wildcard_allowed_resources.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleNotActionOnPermissionsPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleNotActionOnPermissionsPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,11 +17,11 @@ class IamRoleNotActionOnPermissionsPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      violating_policies = role.policy_objects.select do |policy|
-        !policy.policy_document.allows_not_action.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      violating_policies = role.policy_objects.reject do |policy|
+        policy.policy_document.allows_not_action.empty?
       end
-      !violating_policies.empty?
+      violating_policies.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleNotActionOnTrustPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleNotActionOnTrustPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class IamRoleNotActionOnTrustPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      !role.assume_role_policy_document.allows_not_action.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      role.assume_role_policy_document.allows_not_action.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleNotPrincipalOnTrustPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleNotPrincipalOnTrustPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class IamRoleNotPrincipalOnTrustPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      !role.assume_role_policy_document.allows_not_principal.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      role.assume_role_policy_document.allows_not_principal.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleNotResourceOnPermissionsPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleNotResourceOnPermissionsPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,11 +17,11 @@ class IamRoleNotResourceOnPermissionsPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      violating_policies = role.policy_objects.select do |policy|
-        !policy.policy_document.allows_not_resource.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      violating_policies = role.policy_objects.reject do |policy|
+        policy.policy_document.allows_not_resource.empty?
       end
-      !violating_policies.empty?
+      violating_policies.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleWildcardActionOnPermissionsPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleWildcardActionOnPermissionsPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,11 +17,11 @@ class IamRoleWildcardActionOnPermissionsPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      violating_policies = role.policy_objects.select do |policy|
-        !policy.policy_document.wildcard_allowed_actions.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      violating_policies = role.policy_objects.reject do |policy|
+        policy.policy_document.wildcard_allowed_actions.empty?
       end
-      !violating_policies.empty?
+      violating_policies.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleWildcardActionOnTrustPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleWildcardActionOnTrustPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class IamRoleWildcardActionOnTrustPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      !role.assume_role_policy_document.wildcard_allowed_actions.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      role.assume_role_policy_document.wildcard_allowed_actions.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/IamRoleWildcardResourceOnPermissionsPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/IamRoleWildcardResourceOnPermissionsPolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,11 +17,11 @@ class IamRoleWildcardResourceOnPermissionsPolicyRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').select do |role|
-      violating_policies = role.policy_objects.select do |policy|
-        !policy.policy_document.wildcard_allowed_resources.empty?
+    violating_roles = cfn_model.resources_by_type('AWS::IAM::Role').reject do |role|
+      violating_policies = role.policy_objects.reject do |policy|
+        policy.policy_document.wildcard_allowed_resources.empty?
       end
-      !violating_policies.empty?
+      violating_policies.empty?
     end
 
     violating_roles.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/LambdaPermissionInvokeFunctionActionRule.rb
+++ b/lib/cfn-nag/custom_rules/LambdaPermissionInvokeFunctionActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class LambdaPermissionInvokeFunctionActionRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_lambdas = cfn_model.resources_by_type('AWS::Lambda::Permission').select do |lambda_permission|
-      lambda_permission.action != 'lambda:InvokeFunction'
+    violating_lambdas = cfn_model.resources_by_type('AWS::Lambda::Permission').reject do |lambda_permission|
+      lambda_permission.action == 'lambda:InvokeFunction'
     end
 
     violating_lambdas.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/LambdaPermissionWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/LambdaPermissionWildcardPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require 'cfn-model/model/lambda_principal'
 require_relative 'base'

--- a/lib/cfn-nag/custom_rules/ManagedPolicyOnUserRule.rb
+++ b/lib/cfn-nag/custom_rules/ManagedPolicyOnUserRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/PolicyOnUserRule.rb
+++ b/lib/cfn-nag/custom_rules/PolicyOnUserRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/RDSDBClusterStorageEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSDBClusterStorageEncryptedRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/RDSDBInstanceStorageEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSDBInstanceStorageEncryptedRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/RDSInstanceMasterUserPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSInstanceMasterUserPasswordRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -36,21 +38,11 @@ class RDSInstanceMasterUserPasswordRule < BaseRule
   end
 
   def references_no_echo_parameter_without_default?(cfn_model, master_user_password)
-    # i feel like i've written this mess somewhere before
-    if master_user_password.is_a? Hash
-      if master_user_password.key? 'Ref'
-        if cfn_model.parameters.key? master_user_password['Ref']
-          parameter = cfn_model.parameters[master_user_password['Ref']]
+    return false unless master_user_password.is_a? Hash
+    return false unless master_user_password.key? 'Ref'
+    return false unless cfn_model.parameters.key? master_user_password['Ref']
 
-          return to_boolean(parameter.noEcho) && parameter.default.nil?
-        else
-          return false
-        end
-      else
-        return false
-      end
-    end
-    # String or anything weird will fall through here
-    false
+    parameter = cfn_model.parameters[master_user_password['Ref']]
+    to_boolean(parameter.noEcho) && parameter.default.nil?
   end
 end

--- a/lib/cfn-nag/custom_rules/RDSInstanceMasterUsernameRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSInstanceMasterUsernameRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -45,20 +47,11 @@ class RDSInstanceMasterUsernameRule < BaseRule
   end
 
   def references_no_echo_parameter_without_default?(cfn_model, master_username)
-    if master_username.is_a? Hash
-      if master_username.key? 'Ref'
-        if cfn_model.parameters.key? master_username['Ref']
-          parameter = cfn_model.parameters[master_username['Ref']]
+    return false unless master_username.is_a? Hash
+    return false unless master_username.key? 'Ref'
+    return false unless cfn_model.parameters.key? master_username['Ref']
 
-          return to_boolean(parameter.noEcho) && parameter.default.nil?
-        else
-          return false
-        end
-      else
-        return false
-      end
-    end
-    # String or anything weird will fall through here
-    false
+    parameter = cfn_model.parameters[master_username['Ref']]
+    to_boolean(parameter.noEcho) && parameter.default.nil?
   end
 end

--- a/lib/cfn-nag/custom_rules/RDSInstancePubliclyAccessibleRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSInstancePubliclyAccessibleRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/RedshiftClusterEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/RedshiftClusterEncryptedRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/S3BucketPolicyNotActionRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPolicyNotActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class S3BucketPolicyNotActionRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::S3::BucketPolicy').select do |policy|
-      !policy.policy_document.allows_not_action.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::S3::BucketPolicy').reject do |policy|
+      policy.policy_document.allows_not_action.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/S3BucketPolicyNotPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPolicyNotPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class S3BucketPolicyNotPrincipalRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::S3::BucketPolicy').select do |policy|
-      !policy.policy_document.allows_not_principal.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::S3::BucketPolicy').reject do |policy|
+      policy.policy_document.allows_not_principal.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/S3BucketPolicyWildcardActionRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPolicyWildcardActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/S3BucketPolicyWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPolicyWildcardPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/S3BucketPublicReadAclRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPublicReadAclRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/S3BucketPublicReadWriteAclRule.rb
+++ b/lib/cfn-nag/custom_rules/S3BucketPublicReadWriteAclRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/SecurityGroupEgressOpenToWorldRule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupEgressOpenToWorldRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 require 'cfn-nag/ip_addr'

--- a/lib/cfn-nag/custom_rules/SecurityGroupEgressPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupEgressPortRangeRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -19,15 +21,15 @@ class SecurityGroupEgressPortRangeRule < BaseRule
   def audit_impl(cfn_model)
     logical_resource_ids = []
     cfn_model.security_groups.each do |security_group|
-      violating_egresses = security_group.egresses.select do |egress|
-        egress.fromPort != egress.toPort
+      violating_egresses = security_group.egresses.reject do |egress|
+        egress.fromPort == egress.toPort
       end
 
       logical_resource_ids << security_group.logical_resource_id unless violating_egresses.empty?
     end
 
-    violating_egresses = cfn_model.standalone_egress.select do |standalone_egress|
-      standalone_egress.fromPort != standalone_egress.toPort
+    violating_egresses = cfn_model.standalone_egress.reject do |standalone_egress|
+      standalone_egress.fromPort == standalone_egress.toPort
     end
 
     logical_resource_ids + violating_egresses.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SecurityGroupIngressCidrNon32Rule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupIngressCidrNon32Rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 require 'cfn-nag/ip_addr'

--- a/lib/cfn-nag/custom_rules/SecurityGroupIngressOpenToWorldRule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupIngressOpenToWorldRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 require 'cfn-nag/ip_addr'

--- a/lib/cfn-nag/custom_rules/SecurityGroupIngressPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupIngressPortRangeRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -19,15 +21,15 @@ class SecurityGroupIngressPortRangeRule < BaseRule
   def audit_impl(cfn_model)
     logical_resource_ids = []
     cfn_model.security_groups.each do |security_group|
-      violating_ingresses = security_group.ingresses.select do |ingress|
-        ingress.fromPort != ingress.toPort
+      violating_ingresses = security_group.ingresses.reject do |ingress|
+        ingress.fromPort == ingress.toPort
       end
 
       logical_resource_ids << security_group.logical_resource_id unless violating_ingresses.empty?
     end
 
-    violating_ingresses = cfn_model.standalone_ingress.select do |standalone_ingress|
-      standalone_ingress.fromPort != standalone_ingress.toPort
+    violating_ingresses = cfn_model.standalone_ingress.reject do |standalone_ingress|
+      standalone_ingress.fromPort == standalone_ingress.toPort
     end
 
     logical_resource_ids + violating_ingresses.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SecurityGroupMissingEgressRule.rb
+++ b/lib/cfn-nag/custom_rules/SecurityGroupMissingEgressRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/SnsTopicPolicyNotActionRule.rb
+++ b/lib/cfn-nag/custom_rules/SnsTopicPolicyNotActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class SnsTopicPolicyNotActionRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::SNS::TopicPolicy').select do |policy|
-      !policy.policy_document.allows_not_action.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::SNS::TopicPolicy').reject do |policy|
+      policy.policy_document.allows_not_action.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SnsTopicPolicyNotPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/SnsTopicPolicyNotPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class SnsTopicPolicyNotPrincipalRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::SNS::TopicPolicy').select do |policy|
-      !policy.policy_document.allows_not_principal.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::SNS::TopicPolicy').reject do |policy|
+      policy.policy_document.allows_not_principal.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SnsTopicPolicyWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/SnsTopicPolicyWildcardPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/SqsQueuePolicyNotActionRule.rb
+++ b/lib/cfn-nag/custom_rules/SqsQueuePolicyNotActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class SqsQueuePolicyNotActionRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::SQS::QueuePolicy').select do |policy|
-      !policy.policy_document.allows_not_action.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::SQS::QueuePolicy').reject do |policy|
+      policy.policy_document.allows_not_action.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SqsQueuePolicyNotPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/SqsQueuePolicyNotPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -15,8 +17,8 @@ class SqsQueuePolicyNotPrincipalRule < BaseRule
   end
 
   def audit_impl(cfn_model)
-    violating_policies = cfn_model.resources_by_type('AWS::SQS::QueuePolicy').select do |policy|
-      !policy.policy_document.allows_not_principal.empty?
+    violating_policies = cfn_model.resources_by_type('AWS::SQS::QueuePolicy').reject do |policy|
+      policy.policy_document.allows_not_principal.empty?
     end
 
     violating_policies.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/SqsQueuePolicyWildcardActionRule.rb
+++ b/lib/cfn-nag/custom_rules/SqsQueuePolicyWildcardActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/SqsQueuePolicyWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/SqsQueuePolicyWildcardPrincipalRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/UserHasInlinePolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/UserHasInlinePolicyRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/UserMissingGroupRule.rb
+++ b/lib/cfn-nag/custom_rules/UserMissingGroupRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/WafWebAclDefaultActionRule.rb
+++ b/lib/cfn-nag/custom_rules/WafWebAclDefaultActionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copy
 # "MyWebACL": {
 #   "Type": "AWS::WAF::WebACL",

--- a/lib/cfn-nag/custom_rules/WorkspacesWorkspaceEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/WorkspacesWorkspaceEncryptionRule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 require_relative 'base'
 

--- a/lib/cfn-nag/custom_rules/base.rb
+++ b/lib/cfn-nag/custom_rules/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 
 # Base class all Rules should subclass
@@ -16,6 +18,7 @@ class BaseRule
   def audit(cfn_model)
     logical_resource_ids = audit_impl(cfn_model)
     return if logical_resource_ids.empty?
+
     Violation.new(id: rule_id,
                   type: rule_type,
                   message: rule_text,

--- a/lib/cfn-nag/custom_rules/ebs_volumes_jmespath.rb
+++ b/lib/cfn-nag/custom_rules/ebs_volumes_jmespath.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 # failure(id: 'F8888',
 #         jmespath:
 #         "Resources.*|[?Type == 'AWS::EC2::Volume' && " \

--- a/lib/cfn-nag/custom_rules/unencrypted_s3_put_allowed.rb
+++ b/lib/cfn-nag/custom_rules/unencrypted_s3_put_allowed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require 'cfn-nag/violation'
 # require 'model/action_parser'
 #

--- a/lib/cfn-nag/ip_addr.rb
+++ b/lib/cfn-nag/ip_addr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'netaddr'
 
 module IpAddr

--- a/lib/cfn-nag/jmes_path_discovery.rb
+++ b/lib/cfn-nag/jmes_path_discovery.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/UnusedMethodArgument
 class JmesPathDiscovery
   def initialize(rule_registry)
     @rule_registry = rule_registry
@@ -15,3 +18,4 @@ class JmesPathDiscovery
                               message: message)
   end
 end
+# rubocop:enable Lint/UnusedMethodArgument

--- a/lib/cfn-nag/jmes_path_evaluator.rb
+++ b/lib/cfn-nag/jmes_path_evaluator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jmespath'
 require 'logging'
 
@@ -37,12 +39,12 @@ class JmesPathEvaluator
     logical_resource_ids = JMESPath.search(jmespath,
                                            flatten(@cfn_model.raw_model))
 
-    unless logical_resource_ids.empty?
-      @warnings << Violation.new(id: id,
-                                 type: violation_type,
-                                 message: message,
-                                 logical_resource_ids: logical_resource_ids)
-    end
+    return unless logical_resource_ids.empty?
+
+    @warnings << Violation.new(id: id,
+                               type: violation_type,
+                               message: message,
+                               logical_resource_ids: logical_resource_ids)
   end
 
   def flatten(hash)

--- a/lib/cfn-nag/profile.rb
+++ b/lib/cfn-nag/profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 # Container class for profiles

--- a/lib/cfn-nag/profile_loader.rb
+++ b/lib/cfn-nag/profile_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'profile'
 
 # Load rule profile
@@ -17,6 +19,7 @@ class ProfileLoader
 
     profile_definition.each_line do |line|
       next unless (rule_id = rule_line_match(line))
+
       check_valid_rule_id rule_id
       new_profile.add_rule rule_id
     end
@@ -31,6 +34,7 @@ class ProfileLoader
     rule_id = rule_id.chomp
     matches = /^([a-zA-Z]*?[0-9]+)\s*(.*)/.match(rule_id)
     return false if matches.nil?
+
     matches.captures.first
   end
 
@@ -43,6 +47,7 @@ class ProfileLoader
   # else raise an error
   def check_valid_rule_id(rule_id)
     return true unless @rules_registry.by_id(rule_id).nil?
+
     raise "#{rule_id} is not a legal rule identifier from: #{rules_ids}"
   end
 end

--- a/lib/cfn-nag/result_view/json_results.rb
+++ b/lib/cfn-nag/result_view/json_results.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 class JsonResults

--- a/lib/cfn-nag/result_view/rules_view.rb
+++ b/lib/cfn-nag/result_view/rules_view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # View rules warnings/failings
 class RulesView
   def emit(rule_registry, profile)

--- a/lib/cfn-nag/result_view/simple_stdout_results.rb
+++ b/lib/cfn-nag/result_view/simple_stdout_results.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 
 # Print results to STDOUT

--- a/lib/cfn-nag/rule_definition.rb
+++ b/lib/cfn-nag/rule_definition.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class RuleDefinition
-  WARNING = 'WARN'.freeze
-  FAILING_VIOLATION = 'FAIL'.freeze
+  WARNING = 'WARN'
+  FAILING_VIOLATION = 'FAIL'
 
   attr_reader :id, :type, :message
 
@@ -28,7 +30,7 @@ class RuleDefinition
     }
   end
 
-  def ==(other_violation)
-    other_violation.class == self.class && other_violation.to_h == to_h
+  def ==(other)
+    other.class == self.class && other.to_h == to_h
   end
 end

--- a/lib/cfn-nag/rule_dumper.rb
+++ b/lib/cfn-nag/rule_dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'custom_rule_loader'
 require_relative 'profile_loader'
 require_relative 'result_view/rules_view'

--- a/lib/cfn-nag/rule_registry.rb
+++ b/lib/cfn-nag/rule_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rule_definition'
 
 class RuleRegistry

--- a/lib/cfn-nag/template_discovery.rb
+++ b/lib/cfn-nag/template_discovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Container for discovering templates
 class TemplateDiscovery
   # input_json_path can be a directory, filename, or File
@@ -8,6 +10,7 @@ class TemplateDiscovery
                                          template_pattern: template_pattern)
     end
     return [render_path(input_json_path)] if ::File.file? input_json_path
+
     raise "#{input_json_path} is not a proper path"
   end
 
@@ -15,6 +18,7 @@ class TemplateDiscovery
 
   def render_path(path)
     return path.path if path.is_a? File
+
     path
   end
 
@@ -23,9 +27,7 @@ class TemplateDiscovery
 
     templates = []
     Dir[File.join(directory, '**/**')].each do |file_name|
-      if file_name.match(template_pattern)
-        templates << file_name
-      end
+      templates << file_name if file_name.match?(template_pattern)
     end
     templates
   end

--- a/lib/cfn-nag/violation.rb
+++ b/lib/cfn-nag/violation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rule_definition'
 
 # Rule definition for violations

--- a/spec/cfn_nag_integration/cfn_nag_cloudfront_distribution_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_cloudfront_distribution_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_ec2_instance_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_ec2_instance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_ec2_volume_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_ec2_volume_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_elasticloadbalancing_loadbalancer_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_elasticloadbalancing_loadbalancer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_iam_user_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_iam_user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_lambda_permission_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_lambda_permission_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_rds_instance_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_rds_instance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_s3_bucket_policy_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_s3_bucket_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_s3_bucket_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_s3_bucket_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_security_group_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_security_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_sns_policy_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_sns_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_integration/cfn_nag_sqs_policy_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_sqs_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 

--- a/spec/cfn_nag_spec.rb
+++ b/spec/cfn_nag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/cfn_nag'
 require 'cfn-nag/profile_loader'
@@ -224,12 +226,12 @@ EXPECTEDSTDERR
     it 'raises an error' do
       template_name = 'yaml/security_group/sg_with_mangled_metadata.yml'
 
-      expect {
+      expect do
         _ = @cfn_nag.audit_aggregate_across_files(
           input_path: test_template_path(template_name)
         )
-      }.to output('sgOpenIngress2 has missing cfn_nag suppression rule id: [{"reason"=>"This security group is attached to internet-facing ELB"}]' + "\n")
-       .to_stderr_from_any_process
+      end.to output('sgOpenIngress2 has missing cfn_nag suppression rule id: [{"reason"=>"This security group is attached to internet-facing ELB"}]' + "\n")
+        .to_stderr_from_any_process
     end
   end
 

--- a/spec/custom_rule_loader_spec.rb
+++ b/spec/custom_rule_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/custom_rule_loader'
 require 'cfn-nag/rule_definition'
 require 'cfn-nag/rule_registry'
@@ -9,8 +11,8 @@ describe CustomRuleLoader do
       it 'returns RuleRegistry with internal definitions' do
         actual_rule_registry = CustomRuleLoader.new.rule_definitions
 
-        non_rules = actual_rule_registry.rules.select do |rule_definition|
-          !rule_definition.is_a? RuleDefinition
+        non_rules = actual_rule_registry.rules.reject do |rule_definition|
+          rule_definition.is_a? RuleDefinition
         end
         expect(non_rules).to eq []
         expect(actual_rule_registry.rules.size).to be > 10

--- a/spec/custom_rules/CloudFormationAuthenticationRule_spec.rb
+++ b/spec/custom_rules/CloudFormationAuthenticationRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/CloudFormationAuthenticationRule'

--- a/spec/custom_rules/CloudFrontDistributionAccessLoggingRule_spec.rb
+++ b/spec/custom_rules/CloudFrontDistributionAccessLoggingRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/CloudFrontDistributionAccessLoggingRule'

--- a/spec/custom_rules/EbsVolumeHasSseRule_spec.rb
+++ b/spec/custom_rules/EbsVolumeHasSseRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/EbsVolumeHasSseRule'

--- a/spec/custom_rules/ElastiCacheReplicationGroupAtRestEncryptionRule_spec.rb
+++ b/spec/custom_rules/ElastiCacheReplicationGroupAtRestEncryptionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/ElastiCacheReplicationGroupAtRestEncryptionRule'

--- a/spec/custom_rules/ElastiCacheReplicationGroupTransitEncryptionRule_spec.rb
+++ b/spec/custom_rules/ElastiCacheReplicationGroupTransitEncryptionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/ElastiCacheReplicationGroupTransitEncryptionRule'

--- a/spec/custom_rules/ElasticLoadBalancerAccessLoggingRule_spec.rb
+++ b/spec/custom_rules/ElasticLoadBalancerAccessLoggingRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/ElasticLoadBalancerAccessLoggingRule'

--- a/spec/custom_rules/IamManagedPolicyNotActionRule_spec.rb
+++ b/spec/custom_rules/IamManagedPolicyNotActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamManagedPolicyNotActionRule'

--- a/spec/custom_rules/IamManagedPolicyNotResourceRule_spec.rb
+++ b/spec/custom_rules/IamManagedPolicyNotResourceRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamManagedPolicyNotResourceRule'

--- a/spec/custom_rules/IamManagedPolicyWildcardActionRule_spec.rb
+++ b/spec/custom_rules/IamManagedPolicyWildcardActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamManagedPolicyWildcardActionRule'

--- a/spec/custom_rules/IamManagedPolicyWildcardResourceRule_spec.rb
+++ b/spec/custom_rules/IamManagedPolicyWildcardResourceRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamManagedPolicyWildcardResourceRule'

--- a/spec/custom_rules/IamPolicyNotActionRule_spec.rb
+++ b/spec/custom_rules/IamPolicyNotActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamPolicyNotActionRule'

--- a/spec/custom_rules/IamPolicyNotResourceRule_spec.rb
+++ b/spec/custom_rules/IamPolicyNotResourceRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamPolicyNotResourceRule'

--- a/spec/custom_rules/IamPolicyWildcardActionRule_spec.rb
+++ b/spec/custom_rules/IamPolicyWildcardActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamPolicyWildcardActionRule'

--- a/spec/custom_rules/IamPolicyWildcardResourceRule_spec.rb
+++ b/spec/custom_rules/IamPolicyWildcardResourceRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamPolicyWildcardResourceRule'

--- a/spec/custom_rules/IamRoleNotActionOnPermissionsPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleNotActionOnPermissionsPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleNotActionOnPermissionsPolicyRule'

--- a/spec/custom_rules/IamRoleNotActionOnTrustPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleNotActionOnTrustPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleNotActionOnTrustPolicyRule'

--- a/spec/custom_rules/IamRoleNotPrincipalOnTrustPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleNotPrincipalOnTrustPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleNotPrincipalOnTrustPolicyRule'

--- a/spec/custom_rules/IamRoleNotResourceOnPermissionsPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleNotResourceOnPermissionsPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleNotResourceOnPermissionsPolicyRule'

--- a/spec/custom_rules/IamRoleWildcardActionOnPermissionsPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleWildcardActionOnPermissionsPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleWildcardActionOnPermissionsPolicyRule'

--- a/spec/custom_rules/IamRoleWildcardActionOnTrustPolicyRule_spec.rb
+++ b/spec/custom_rules/IamRoleWildcardActionOnTrustPolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/IamRoleWildcardActionOnTrustPolicyRule'

--- a/spec/custom_rules/LambdaPermissionInvokeFunctionActionRule_spec.rb
+++ b/spec/custom_rules/LambdaPermissionInvokeFunctionActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/LambdaPermissionInvokeFunctionActionRule'

--- a/spec/custom_rules/LambdaPermissionWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/LambdaPermissionWildcardPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/LambdaPermissionWildcardPrincipalRule'

--- a/spec/custom_rules/ManagedPolicyOnUserRule_spec.rb
+++ b/spec/custom_rules/ManagedPolicyOnUserRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/ManagedPolicyOnUserRule'

--- a/spec/custom_rules/PolicyOnUserRule_spec.rb
+++ b/spec/custom_rules/PolicyOnUserRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/PolicyOnUserRule'

--- a/spec/custom_rules/RDSInstanceMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSInstanceMasterUserPasswordRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/RDSInstanceMasterUserPasswordRule'

--- a/spec/custom_rules/RDSInstanceMasterUsernameRule_spec.rb
+++ b/spec/custom_rules/RDSInstanceMasterUsernameRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/RDSInstanceMasterUsernameRule'

--- a/spec/custom_rules/RDSInstancePubliclyAccessibleRule_spec.rb
+++ b/spec/custom_rules/RDSInstancePubliclyAccessibleRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/RDSInstancePubliclyAccessibleRule'

--- a/spec/custom_rules/S3BucketPolicyNotActionRule_spec.rb
+++ b/spec/custom_rules/S3BucketPolicyNotActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/S3BucketPolicyNotActionRule'

--- a/spec/custom_rules/S3BucketPolicyNotPrincipalRule_spec.rb
+++ b/spec/custom_rules/S3BucketPolicyNotPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/S3BucketPolicyNotPrincipalRule'

--- a/spec/custom_rules/S3BucketPolicyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/S3BucketPolicyWildcardPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/S3BucketPolicyWildcardPrincipalRule'

--- a/spec/custom_rules/S3BucketPublicReadAclRule_spec.rb
+++ b/spec/custom_rules/S3BucketPublicReadAclRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/S3BucketPublicReadAclRule'

--- a/spec/custom_rules/S3BucketPublicReadWriteAclRule_spec.rb
+++ b/spec/custom_rules/S3BucketPublicReadWriteAclRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/S3BucketPublicReadWriteAclRule'

--- a/spec/custom_rules/SecurityGroupEgressOpenToWorldRule_spec.rb
+++ b/spec/custom_rules/SecurityGroupEgressOpenToWorldRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SecurityGroupEgressOpenToWorldRule'

--- a/spec/custom_rules/SecurityGroupEgressPortRangeRule_spec.rb
+++ b/spec/custom_rules/SecurityGroupEgressPortRangeRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SecurityGroupEgressPortRangeRule'

--- a/spec/custom_rules/SecurityGroupIngressCidrNon32Rule_spec.rb
+++ b/spec/custom_rules/SecurityGroupIngressCidrNon32Rule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SecurityGroupIngressCidrNon32Rule'

--- a/spec/custom_rules/SecurityGroupIngressOpenToWorldRule_spec.rb
+++ b/spec/custom_rules/SecurityGroupIngressOpenToWorldRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SecurityGroupIngressOpenToWorldRule'

--- a/spec/custom_rules/SecurityGroupIngressPortRangeRule_spec.rb
+++ b/spec/custom_rules/SecurityGroupIngressPortRangeRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SecurityGroupIngressPortRangeRule'

--- a/spec/custom_rules/SecurityGroupMissingEgressRule_spec.rb
+++ b/spec/custom_rules/SecurityGroupMissingEgressRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/custom_rules/SecurityGroupMissingEgressRule'
 require 'cfn-model'

--- a/spec/custom_rules/SnsTopicPolicyNotActionRule_spec.rb
+++ b/spec/custom_rules/SnsTopicPolicyNotActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SnsTopicPolicyNotActionRule'

--- a/spec/custom_rules/SnsTopicPolicyNotPrincipalRule_spec.rb
+++ b/spec/custom_rules/SnsTopicPolicyNotPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SnsTopicPolicyNotPrincipalRule'

--- a/spec/custom_rules/SnsTopicPolicyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/SnsTopicPolicyWildcardPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SnsTopicPolicyWildcardPrincipalRule'

--- a/spec/custom_rules/SqsQueuePolicyNotActionRule_spec.rb
+++ b/spec/custom_rules/SqsQueuePolicyNotActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SqsQueuePolicyNotActionRule'

--- a/spec/custom_rules/SqsQueuePolicyNotPrincipalRule_spec.rb
+++ b/spec/custom_rules/SqsQueuePolicyNotPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SqsQueuePolicyNotPrincipalRule'

--- a/spec/custom_rules/SqsQueuePolicyWildcardActionRule_spec.rb
+++ b/spec/custom_rules/SqsQueuePolicyWildcardActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SqsQueuePolicyWildcardActionRule'

--- a/spec/custom_rules/SqsQueuePolicyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/SqsQueuePolicyWildcardPrincipalRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/SqsQueuePolicyWildcardPrincipalRule'

--- a/spec/custom_rules/UserHasInlinePolicyRule_spec.rb
+++ b/spec/custom_rules/UserHasInlinePolicyRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/UserHasInlinePolicyRule'

--- a/spec/custom_rules/UserMissingGroupRule_spec.rb
+++ b/spec/custom_rules/UserMissingGroupRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/custom_rules/UserMissingGroupRule'
 require 'cfn-model'

--- a/spec/custom_rules/WafWebAclDefaultActionRule_spec.rb
+++ b/spec/custom_rules/WafWebAclDefaultActionRule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/WafWebAclDefaultActionRule'

--- a/spec/custom_rules/base_spec.rb
+++ b/spec/custom_rules/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/base'

--- a/spec/profile_loader_spec.rb
+++ b/spec/profile_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/profile_loader'
 require 'cfn-nag/rule_registry'

--- a/spec/rule_definition_spec.rb
+++ b/spec/rule_definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/rule_definition'
 
 describe RuleDefinition do

--- a/spec/rule_dumper_spec.rb
+++ b/spec/rule_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/rule_dumper'
 
 describe CfnNagRuleDumper do

--- a/spec/rule_registry_spec.rb
+++ b/spec/rule_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/rule_registry'
 require 'cfn-nag/rule_definition'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start do
   add_filter 'spec/'

--- a/spec/template_discovery_spec.rb
+++ b/spec/template_discovery_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'cfn-nag/template_discovery'
 require 'tempfile'

--- a/spec/violation_spec.rb
+++ b/spec/violation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/violation'
 
 describe Violation do


### PR DESCRIPTION
Goals:

* Configure a starting point for rubocop. It isn't perfect, but at least gives us a place to start
* Fix as many violations as possible
* Ensure tests still pass
* Fail Circle builds if rubocop does not pass.

As a side effect we are dropping ruby 2.2.x (no longer supported) for 2.4.x (and also 2.5.x)