### PR TITLE
Re-enabling rubocop as part of CI process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: bundle check || bundle install
       - run:
           name: Rubocop lint
-          command: bundle exec rubocop -D || echo Looks like you failed a lint
+          command: bundle exec rubocop -D
       - run:
           name: Rspec tests
           command: bundle exec rspec --color --require spec_helper spec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,88 @@
 AllCops:
   TargetRubyVersion: 2.5
-Layout/IndentHeredoc:
+  Exclude:
+    - 'spec/**/*'
+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
-# not a bad notion except when you are actually trying to select things that are not(something)
+Performance/RegexpMatch:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Naming/FileName:
+  Enabled: false
+
 Style/InverseMethods:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 16
+
+Security/Eval:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/StderrPuts:
+  Enabled: false
+
+Style/RedundantBegin:
+  Enabled: false
+
+Lint/RescueException:
+  Enabled: false
+
+Layout/LeadingBlankLines:
+  Enabled: false
+
+Layout/TrailingBlankLines:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
+Lint/StringConversionInInterpolation:
+  Enabled: false
+
+Style/Next:
   Enabled: false

--- a/lib/cfn-nag.rb
+++ b/lib/cfn-nag.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Naming/FileName
 require 'cfn-nag/cfn_nag'
 require 'cfn-nag/violation'
 require 'cfn-nag/rule_dumper'
-# rubocop:enable Naming/FileName

--- a/lib/cfn-nag/cfn_nag.rb
+++ b/lib/cfn-nag/cfn_nag.rb
@@ -44,8 +44,6 @@ class CfnNag
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
-
   ##
   # Given a file or directory path, return aggregate results
   #
@@ -65,9 +63,6 @@ class CfnNag
     end
     aggregate_results
   end
-  # rubocop:enable Metrics/MethodLength
-
-  # rubocop:disable Metrics/MethodLength
 
   ##
   # Given cloudformation json/yml, run all the rules against it
@@ -100,7 +95,6 @@ class CfnNag
       violations: violations
     }
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.configure_logging(opts)
     logger = Logging.logger['log']

--- a/lib/cfn-nag/custom_rules/.rubocop.yml
+++ b/lib/cfn-nag/custom_rules/.rubocop.yml
@@ -1,4 +1,0 @@
-Naming/FileName:
-  Enabled: false
-LineLength:
-  Max: 120


### PR DESCRIPTION
1. Fail CircleCI build if rubocop finds violations
2. Disable all rules that are failing to achieve a clean CI run

This will set us up to be able to enable a rule at a time in future individual PRs