### PR TITLE
Add NeptuneDBCluster Storage Encryption Check

### DIFF
--- a/lib/cfn-nag/custom_rules/NeptuneDBClusterStorageEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/NeptuneDBClusterStorageEncryptedRule.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class NeptuneDBClusterStorageEncryptedRule < BaseRule
+  def rule_text
+    'Neptune database cluster storage should have encryption enabled'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F30'
+  end
+
+  def audit_impl(cfn_model)
+    resources = cfn_model.resources_by_type('AWS::Neptune::DBCluster')
+
+    violating_storage = resources.select do |filesystem|
+      filesystem.storageEncrypted.nil? ||
+        filesystem.storageEncrypted.to_s.casecmp('false').zero?
+    end
+
+    violating_storage.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/NeptuneDBClusterStorageEncryptedRule_spec.rb
+++ b/spec/custom_rules/NeptuneDBClusterStorageEncryptedRule_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/NeptuneDBClusterStorageEncryptedRule'
+
+describe NeptuneDBClusterStorageEncryptedRule do
+  context 'Neptune database storage without encryption' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/neptune/with_no_encryption.json'
+      )
+
+      actual_logical_resource_ids = NeptuneDBClusterStorageEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[NeptuneDBCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Neptune database storage with encryption' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template('json/neptune/with_encryption.json')
+
+      actual_logical_resource_ids = NeptuneDBClusterStorageEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = []
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Neptune database storage encryption set to false string' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/neptune/with_encryption_false_string.json')
+
+      actual_logical_resource_ids = NeptuneDBClusterStorageEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[NeptuneDBCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Neptune database storage encryption set to false boolean' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/neptune/with_encryption_false_boolean.json')
+
+      actual_logical_resource_ids = NeptuneDBClusterStorageEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[NeptuneDBCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/json/neptune/with_encryption.json
+++ b/spec/test_templates/json/neptune/with_encryption.json
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Neptune encrypted storage test template",
+
+  "Resources" : {
+    "NeptuneDBCluster" : {
+      "Type" : "AWS::Neptune::DBCluster",
+      "Properties" :
+      {
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "IamAuthEnabled" : false,
+        "StorageEncrypted" : true
+      }
+    },
+    "NeptuneDBInstance" : {
+      "Type" : "AWS::Neptune::DBInstance",
+      "Properties" :
+      {        
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "DBInstanceClass" : "db.r4.large"
+      },
+      "DependsOn" : "NeptuneDBCluster"
+    }
+  }
+}

--- a/spec/test_templates/json/neptune/with_encryption_false_boolean.json
+++ b/spec/test_templates/json/neptune/with_encryption_false_boolean.json
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Neptune encrypted storage test template",
+
+  "Resources" : {
+    "NeptuneDBCluster" : {
+      "Type" : "AWS::Neptune::DBCluster",
+      "Properties" :
+      {
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "IamAuthEnabled" : false,
+        "StorageEncrypted" : false
+      }
+    },
+    "NeptuneDBInstance" : {
+      "Type" : "AWS::Neptune::DBInstance",
+      "Properties" :
+      {        
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "DBInstanceClass" : "db.r4.large"
+      },
+      "DependsOn" : "NeptuneDBCluster"
+    }
+  }
+}

--- a/spec/test_templates/json/neptune/with_encryption_false_string.json
+++ b/spec/test_templates/json/neptune/with_encryption_false_string.json
@@ -1,0 +1,26 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Neptune encrypted storage test template",
+
+  "Resources" : {
+    "NeptuneDBCluster" : {
+      "Type" : "AWS::Neptune::DBCluster",
+      "Properties" :
+      {
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "IamAuthEnabled" : false,
+        "StorageEncrypted" : "false"
+      }
+    },
+    "NeptuneDBInstance" : {
+      "Type" : "AWS::Neptune::DBInstance",
+      "Properties" :
+      {        
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "DBInstanceClass" : "db.r4.large"
+      },
+      "DependsOn" : "NeptuneDBCluster"
+    }
+  }
+}

--- a/spec/test_templates/json/neptune/with_no_encryption.json
+++ b/spec/test_templates/json/neptune/with_no_encryption.json
@@ -1,0 +1,25 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Neptune encrypted storage test template",
+
+  "Resources" : {
+    "NeptuneDBCluster" : {
+      "Type" : "AWS::Neptune::DBCluster",
+      "Properties" :
+      {
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "IamAuthEnabled" : false,
+      }
+    },
+    "NeptuneDBInstance" : {
+      "Type" : "AWS::Neptune::DBInstance",
+      "Properties" :
+      {        
+        "DBClusterIdentifier" : "neptune-test-cluster",
+        "DBInstanceClass" : "db.r4.large"
+      },
+      "DependsOn" : "NeptuneDBCluster"
+    }
+  }
+}


### PR DESCRIPTION
Closes #131; adds a NeptuneDBClusterStorageEncrypted rule to ensure Neptune database clusters are properly set with encryption enabled