### PR TITLE
Add CodeBuild::Project Missing EncryptionKey Warning

### DIFF
--- a/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
+++ b/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+# Rule class to ensure a CF distribution has logging
+class CodeBuildEncryptionKeyRule < BaseRule
+  def rule_text
+    'CodeBuild project should specify an EncryptionKey value'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W32'
+  end
+
+  def audit_impl(cfn_model)
+    violating_projects = cfn_model.resources_by_type('AWS::CodeBuild::Project')
+                                       .select do |project|
+      project.encryptionKey.nil?
+    end
+
+    violating_projects.map(&:logical_resource_id)
+  end
+end

--- a/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
+++ b/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
@@ -3,7 +3,7 @@
 require 'cfn-nag/violation'
 require_relative 'base'
 
-# Rule class to ensure a CF distribution has logging
+# Rule class to warn on CodeBuild::Project without an EncryptionKey specified
 class CodeBuildEncryptionKeyRule < BaseRule
   def rule_text
     'CodeBuild project should specify an EncryptionKey value'

--- a/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
+++ b/lib/cfn-nag/custom_rules/CodeBuildEncryptionKeyRule.rb
@@ -19,7 +19,7 @@ class CodeBuildEncryptionKeyRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_projects = cfn_model.resources_by_type('AWS::CodeBuild::Project')
-                                       .select do |project|
+                                  .select do |project|
       project.encryptionKey.nil?
     end
 

--- a/spec/custom_rules/CodeBuildEncryptionKeyRule_spec.rb
+++ b/spec/custom_rules/CodeBuildEncryptionKeyRule_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/CodeBuildEncryptionKeyRule'
+
+describe CodeBuildEncryptionKeyRule do
+  context 'CodeBuild Project without a specified encryption key' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/codebuild/without_encryption_key.json'
+      )
+
+      actual_logical_resource_ids = CodeBuildEncryptionKeyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[Project]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'CodeBuild Project with a specified encryption key' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/codebuild/with_encryption_key.json'
+      )
+
+      actual_logical_resource_ids = CodeBuildEncryptionKeyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = []
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/json/codebuild/with_encryption_key.json
+++ b/spec/test_templates/json/codebuild/with_encryption_key.json
@@ -1,0 +1,28 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "CodeBuild Project with encryption key correctly specified",
+
+  "Resources" : {
+    "Project": {
+      "Type": "AWS::CodeBuild::Project",
+      "Properties": {
+        "Name": "fakeCFNNagProject",
+        "EncryptionKey": "some/valid/key",
+        "ServiceRole": "arn:aws:iam::accountNumber:role/service-role/ami_codebuild",
+        "Artifacts": {
+          "Type": "NO_ARTIFACTS"
+        },
+        "Environment": {
+          "Type": "LINUX_CONTAINER",
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/java:openjdk-8",
+        },
+        "Source": {
+          "Location": "/fake/invalid/s3/bucket/path",
+          "Type": "S3"
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/codebuild/without_encryption_key.json
+++ b/spec/test_templates/json/codebuild/without_encryption_key.json
@@ -1,0 +1,27 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "CodeBuild Project with no encryption key specified",
+
+  "Resources" : {
+    "Project": {
+      "Type": "AWS::CodeBuild::Project",
+      "Properties": {
+        "Name": "fakeCFNNagProject",
+        "ServiceRole": "arn:aws:iam::324320755747:role/service-role/ami_codebuild",
+        "Artifacts": {
+          "Type": "NO_ARTIFACTS"
+        },
+        "Environment": {
+          "Type": "LINUX_CONTAINER",
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/java:openjdk-8",
+        },
+        "Source": {
+          "Location": "/fake/invalid/s3/bucket/path",
+          "Type": "S3"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #69; Adds a Warning on no specified EncryptionKey for a CodeBuild::Project resource