### PR TITLE
Add RuboCop vendor directory exclusion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - 'spec/**/*'
+    - 'vendor/**/*'
 
 Style/IfUnlessModifier:
   Enabled: false


### PR DESCRIPTION
Optional PR. Adds an exclusion for a vendor directory for people who use bundle to install dependencies; otherwise a bundled gem (like rainbow 3.0.0) that includes its .rubocop.yml can conflict