### PR TITLE
Hotfix RDS DBInstance With ClusterIdentifier

### DIFF
--- a/lib/cfn-nag/custom_rules/RDSDBInstanceStorageEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSDBInstanceStorageEncryptedRule.rb
@@ -20,8 +20,11 @@ class RDSDBInstanceStorageEncryptedRule < BaseRule
     resources = cfn_model.resources_by_type('AWS::RDS::DBInstance')
 
     violating_instances = resources.select do |instance|
-      instance.storageEncrypted.nil? ||
-        instance.storageEncrypted.to_s.casecmp('false').zero?
+      instance.dBClusterIdentifier.nil? &&
+        (
+          instance.storageEncrypted.nil? ||
+          instance.storageEncrypted.to_s.casecmp('false').zero?
+        )
     end
 
     violating_instances.map(&:logical_resource_id)

--- a/spec/custom_rules/RDSDBInstanceStorageEncryptedRule_spec.rb
+++ b/spec/custom_rules/RDSDBInstanceStorageEncryptedRule_spec.rb
@@ -3,6 +3,20 @@ require 'cfn-model'
 require 'cfn-nag/custom_rules/RDSDBInstanceStorageEncryptedRule'
 
 describe RDSDBInstanceStorageEncryptedRule do
+
+  context 'DB Instance with cluster identifier' do
+    it 'inherits the cluster\'s encryption, and therefore passes' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/rds_instance/db_instance_with_clusterid_and_encryption_false.json'
+      )
+
+      actual_logical_resource_ids = RDSDBInstanceStorageEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
   context 'DB Instance without encryption' do
     it 'returns offending logical resource id' do
       cfn_model = CfnParser.new.parse read_test_template(

--- a/spec/test_templates/json/rds_instance/db_instance_with_clusterid_and_encryption_false.json
+++ b/spec/test_templates/json/rds_instance/db_instance_with_clusterid_and_encryption_false.json
@@ -1,0 +1,17 @@
+{
+  "Resources": {
+    "MyDB" : {
+      "Type" : "AWS::RDS::DBInstance",
+      "Properties" : {
+        "AllocatedStorage" : "100",
+        "DBClusterIdentifier" : "clusterId",
+        "DBInstanceClass" : "db.m1.small",
+        "Engine" : "MySQL",
+        "EngineVersion" : "5.6.13",
+        "Iops" : "1000",
+        "PubliclyAccessible": "false",
+        "StorageEncrypted": "false"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #183; RDS database instances inherit the cluster's encryption status (if they are part of a cluster); fixes a false positive on database instance encryption in cases where a cluster identifier was present