### PR TITLE
Add fail-on-warnings option

### DIFF
--- a/bin/cfn_nag
+++ b/bin/cfn_nag
@@ -57,6 +57,11 @@ opts = Trollop.options do
       type: :boolean,
       required: false,
       default: false
+  opt :fail_on_warnings,
+      'Treat warnings as failing violations',
+      type: :boolean,
+      required: false,
+      default: false
 end
 # rubocop:enable Metrics/BlockLength
 
@@ -92,7 +97,12 @@ until ARGF.closed? || ARGF.eof?
                           parameter_values_string: parameter_values_string)
   ARGF.close
 
-  total_failure_count += results[:failure_count]
+  unless opts[:fail_on_warnings]
+    total_failure_count += results[:failure_count]
+  else
+    total_failure_count = results[:violations].length
+  end
+
   results[:violations] = results[:violations].map(&:to_h)
   puts JSON.pretty_generate(results)
 end

--- a/bin/cfn_nag
+++ b/bin/cfn_nag
@@ -97,10 +97,10 @@ until ARGF.closed? || ARGF.eof?
                           parameter_values_string: parameter_values_string)
   ARGF.close
 
-  unless opts[:fail_on_warnings]
-    total_failure_count += results[:failure_count]
+  if opts[:fail_on_warnings]
+    total_failure_count += results[:violations].length
   else
-    total_failure_count = results[:violations].length
+    total_failure_count += results[:failure_count]
   end
 
   results[:violations] = results[:violations].map(&:to_h)

--- a/bin/cfn_nag
+++ b/bin/cfn_nag
@@ -97,11 +97,11 @@ until ARGF.closed? || ARGF.eof?
                           parameter_values_string: parameter_values_string)
   ARGF.close
 
-  if opts[:fail_on_warnings]
-    total_failure_count += results[:violations].length
-  else
-    total_failure_count += results[:failure_count]
-  end
+  total_failure_count += if opts[:fail_on_warnings]
+                           results[:violations].length
+                         else
+                           results[:failure_count]
+                         end
 
   results[:violations] = results[:violations].map(&:to_h)
   puts JSON.pretty_generate(results)


### PR DESCRIPTION
Closes #84; Adds a fail-on-warnings command line option; when enabled, fail-on-warnings causes the exit code to be equal to the total number of failings and warnings; if fail-on-warnings is not specified, the previous behavior (zero exit status on warnings, nonzero exit status on failures) persists; the option is disabled by default