### PR TITLE
Warn on Privileged=true for ContainerProperties in AWS::Batch::JobDefinition

### DIFF
--- a/lib/cfn-nag/custom_rules/BatchJobDefinitionContainerPropertiesPrivilegedRule.rb
+++ b/lib/cfn-nag/custom_rules/BatchJobDefinitionContainerPropertiesPrivilegedRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class BatchJobDefinitionContainerPropertiesPrivilegedRule < BaseRule
+  def rule_text
+    'Batch Job Definition Container Properties should not have Privileged set to true'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W34'
+  end
+
+  def audit_impl(cfn_model)
+    violating_job_definitions = cfn_model.resources_by_type('AWS::Batch::JobDefinition')
+                                         .select do |job_definition|
+      truthy?(job_definition.containerProperties['Privileged'])
+    end
+
+    violating_job_definitions.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/BatchJobDefinitionContainerPropertiesPrivilegedRule_spec.rb
+++ b/spec/custom_rules/BatchJobDefinitionContainerPropertiesPrivilegedRule_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/BatchJobDefinitionContainerPropertiesPrivilegedRule'
+
+describe BatchJobDefinitionContainerPropertiesPrivilegedRule do
+  context 'when Batch::JobDefinition ContainerProperties does not have Privileged specified' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_no_container_properties_priveleged_specified.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==true boolean' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[BatchJobDefinition]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==True Boolean' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[BatchJobDefinition]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==true string' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[BatchJobDefinition]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==True String' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[BatchJobDefinition]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==false boolean' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==False Boolean' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==false string' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when Batch::JobDefinition ContainerProperties has Privileged==false string' do
+    it 'returns offending logical resource id for offending JobDefinition' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        BatchJobDefinitionContainerPropertiesPrivilegedRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: false
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean_case.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_boolean_case.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: False
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: 'false'
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string_case.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_false_string_case.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: 'False'
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: true
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean_case.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_boolean_case.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: True
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: 'true'
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string_case.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_container_properties_priveleged_true_string_case.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Privileged: 'True'
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent

--- a/spec/test_templates/yaml/batch/batch_jobdefinition_no_container_properties_priveleged_specified.yml
+++ b/spec/test_templates/yaml/batch/batch_jobdefinition_no_container_properties_priveleged_specified.yml
@@ -1,0 +1,10 @@
+---
+Resources:
+  BatchJobDefinition:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      ContainerProperties:
+        Memory: 512
+        Vcpus: 1
+        Image: amazon/amazon-ecs-agent


### PR DESCRIPTION
This creates a new Warning rule whenever the Privileged is set to true for the ContainerProperties for AWS::Batch::JobDefinition. This checks against both the Boolean or String values for true.

This takes care of Issue #71.

```
W34 Batch Job Definition Container Properties should not have Privileged set to true
```