### PR TITLE
Warn on MapPublicIpOnLaunch=True in AWS::EC2::Subnet

### DIFF
--- a/lib/cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule.rb
+++ b/lib/cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule.rb
@@ -19,7 +19,7 @@ class EC2SubnetMapPublicIpOnLaunchRule < BaseRule
   def audit_impl(cfn_model)
     violating_subnets = cfn_model.resources_by_type('AWS::EC2::Subnet')
                                  .select do |subnet|
-      subnet.mapPublicIpOnLaunch.to_s == 'true'
+      truthy?(subnet.mapPublicIpOnLaunch)
     end
 
     violating_subnets.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule.rb
+++ b/lib/cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class EC2SubnetMapPublicIpOnLaunchRule < BaseRule
+  def rule_text
+    'EC2 Subnet should not have MapPublicIpOnLaunch set to true'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W33'
+  end
+
+  def audit_impl(cfn_model)
+    violating_subnets = cfn_model.resources_by_type('AWS::EC2::Subnet')
+                                 .select do |subnet|
+      subnet.mapPublicIpOnLaunch.to_s == 'true'
+    end
+
+    violating_subnets.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
+++ b/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
@@ -18,10 +18,25 @@ describe EC2SubnetMapPublicIpOnLaunchRule do
     end
   end
 
-  context 'when EC2::Subnet has MapPublicIpOnLaunch==true' do
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==true boolean' do
     it 'returns offending logical resource id for offending Subnet' do
       cfn_model = CfnParser.new.parse read_test_template(
         'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[EC2Subnet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==True Boolean' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean_case.yml'
       )
 
       actual_logical_resource_ids =
@@ -48,6 +63,21 @@ describe EC2SubnetMapPublicIpOnLaunchRule do
     end
   end
 
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==True String' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[EC2Subnet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
   context 'when EC2::Subnet has MapPublicIpOnLaunch==false boolean' do
     it 'returns offending logical resource id for offending Subnet' do
       cfn_model = CfnParser.new.parse read_test_template(
@@ -63,10 +93,40 @@ describe EC2SubnetMapPublicIpOnLaunchRule do
     end
   end
 
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==False Boolean' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean_case.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
   context 'when EC2::Subnet has MapPublicIpOnLaunch==false string' do
     it 'returns offending logical resource id for offending Subnet' do
       cfn_model = CfnParser.new.parse read_test_template(
         'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==False String' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string_case.yml'
       )
 
       actual_logical_resource_ids =

--- a/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
+++ b/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule'
+
+describe EC2SubnetMapPublicIpOnLaunchRule do
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==true' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[EC2Subnet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==true string' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[EC2Subnet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
+++ b/spec/custom_rules/EC2SubnetMapPublicIpOnLaunchRule_spec.rb
@@ -3,6 +3,21 @@ require 'cfn-model'
 require 'cfn-nag/custom_rules/EC2SubnetMapPublicIpOnLaunchRule'
 
 describe EC2SubnetMapPublicIpOnLaunchRule do
+  context 'when EC2::Subnet does not have MapPublicIpOnLaunch specified' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_no_map_public_ip_on_launch_specified.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
   context 'when EC2::Subnet has MapPublicIpOnLaunch==true' do
     it 'returns offending logical resource id for offending Subnet' do
       cfn_model = CfnParser.new.parse read_test_template(
@@ -28,6 +43,36 @@ describe EC2SubnetMapPublicIpOnLaunchRule do
         EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
 
       expected_logical_resource_ids = %w[EC2Subnet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==false boolean' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'when EC2::Subnet has MapPublicIpOnLaunch==false string' do
+    it 'returns offending logical resource id for offending Subnet' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string.yml'
+      )
+
+      actual_logical_resource_ids =
+        EC2SubnetMapPublicIpOnLaunchRule.new.audit_impl cfn_model
+
+      expected_logical_resource_ids = %w[]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
     end

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: false
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean_case.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_boolean_case.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: False
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: 'false'
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string_case.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_false_string_case.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: 'False'
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: true
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean_case.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_boolean_case.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: True
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: 'true'
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string_case.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_map_public_ip_on_launch_true_string_case.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      MapPublicIpOnLaunch: 'True'
+      VpcId: vpc-abcde12345

--- a/spec/test_templates/yaml/ec2_subnet/ec2_subnet_no_map_public_ip_on_launch_specified.yml
+++ b/spec/test_templates/yaml/ec2_subnet/ec2_subnet_no_map_public_ip_on_launch_specified.yml
@@ -1,0 +1,8 @@
+---
+Resources:
+  EC2Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: '10.0.0.0/24'
+      VpcId: vpc-abcde12345


### PR DESCRIPTION
This creates a new Warning rule whenever the `MapPublicIpOnLaunch` is set to `true` for `AWS::EC2::Subnet`. This checks against both the Boolean or String values for true.

This takes care of Issue #62. 

```
W33 EC2 Subnet should not have MapPublicIpOnLaunch set to true
```