### PR TITLE
Fail on not utilizing NoEcho for MasterUserPassword in AWS::RDS::DBCluster

### DIFF
--- a/lib/cfn-nag/custom_rules/RDSDBClusterMasterUserPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/RDSDBClusterMasterUserPasswordRule.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_noecho_parameter.rb'
+require_relative 'base'
+
+class RDSDBClusterMasterUserPasswordRule < BaseRule
+  def rule_text
+    'RDS DB Cluster master user password must be Ref to NoEcho Parameter. ' \
+    'Default credentials are not recommended'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F32'
+  end
+
+  def audit_impl(cfn_model)
+    rds_dbclusters = cfn_model.resources_by_type('AWS::RDS::DBCluster')
+    violating_rdsclusters = rds_dbclusters.select do |cluster|
+      if cluster.masterUserPassword.nil?
+        false
+      else
+        !no_echo_parameter_without_default?(cfn_model,
+                                            cluster.masterUserPassword)
+      end
+    end
+
+    violating_rdsclusters.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
@@ -4,7 +4,7 @@ require 'cfn-nag/custom_rules/RDSDBClusterMasterUserPasswordRule'
 
 describe RDSDBClusterMasterUserPasswordRule, :rule do
   context 'RDS DB Cluster without master user password set' do
-    it 'returns offending logical resource id for offending DBCluster' do
+    it 'returns empty list' do
       cfn_model = CfnParser.new.parse read_test_template(
         'yaml/rds_dbcluster/rds_dbcluster_no_master_user_password.yml'
       )
@@ -18,7 +18,7 @@ describe RDSDBClusterMasterUserPasswordRule, :rule do
   end
 
   context 'RDS DB Cluster with parameter master user password with NoEcho' do
-    it 'returns offending logical resource id for offending DBCluster' do
+    it 'returns empty list' do
       cfn_model = CfnParser.new.parse read_test_template(
         'yaml/rds_dbcluster/' \
         'rds_dbcluster_master_user_password_parameter_noecho.yml'

--- a/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/RDSDBClusterMasterUserPasswordRule'
+
+describe RDSDBClusterMasterUserPasswordRule, :rule do
+  context 'RDS DB Cluster without master user password set' do
+    it 'returns offending logical resource id for offending DBCluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/rds_dbcluster/rds_dbcluster_no_master_user_password.yml'
+      )
+
+      actual_logical_resource_ids =
+        RDSDBClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'RDS DB Cluster with parameter master user password with NoEcho' do
+    it 'returns offending logical resource id for offending DBCluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/rds_dbcluster/' \
+        'rds_dbcluster_master_user_password_parameter_noecho.yml'
+      )
+
+      actual_logical_resource_ids =
+        RDSDBClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'RDS DB Cluster with literal master user password in plaintext' do
+    it 'returns offending logical resource id for offending DBCluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/rds_dbcluster/rds_dbcluster_master_user_password_plaintext.yml'
+      )
+
+      actual_logical_resource_ids =
+        RDSDBClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[RDSDBCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'RDS DB Cluster with parameter master user password with NoEcho' \
+    'that has Default value' do
+    it 'returns offending logical resource id for offending DBCluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/rds_dbcluster/' \
+        'rds_dbcluster_master_user_password_parameter_noecho_with_default.yml'
+      )
+      actual_logical_resource_ids =
+        RDSDBClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[RDSDBCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_parameter_noecho.yml
+++ b/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_parameter_noecho.yml
@@ -1,0 +1,14 @@
+---
+Parameters:
+  DBClusterMasterUserPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  RDSDBCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DeletionProtection: True
+      Engine: aurora-mysql
+      MasterUserPassword: !Ref DBClusterMasterUserPassword
+      MasterUsername: admin
+      Port: 3306

--- a/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_parameter_noecho_with_default.yml
+++ b/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_parameter_noecho_with_default.yml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  DBClusterMasterUserPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  RDSDBCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DeletionProtection: True
+      Engine: aurora-mysql
+      MasterUserPassword: !Ref DBClusterMasterUserPassword
+      MasterUsername: admin
+      Port: 3306

--- a/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_plaintext.yml
+++ b/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_master_user_password_plaintext.yml
@@ -1,0 +1,10 @@
+---
+Resources:
+  RDSDBCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DeletionProtection: True
+      Engine: aurora-mysql
+      MasterUserPassword: b@dP@$sW0rD
+      MasterUsername: admin
+      Port: 3306

--- a/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_no_master_user_password.yml
+++ b/spec/test_templates/yaml/rds_dbcluster/rds_dbcluster_no_master_user_password.yml
@@ -1,0 +1,9 @@
+---
+Resources:
+  RDSDBCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      DeletionProtection: True
+      Engine: aurora-mysql
+      MasterUsername: admin
+      Port: 3306


### PR DESCRIPTION
This creates a new Failing rule whenever the `MasterUserPassword` for RDS DBCluster is set in plaintext either in the resource itself, or as a default from a parameter. If `MasterUserPassword` for RDS DBCluster is specified, then it needs to be set as a parameter with `NoEcho`.

This takes care of [Story #164842091](https://www.pivotaltracker.com/story/show/164842091)

```
F32 RDS DB Cluster master user password must be Ref to NoEcho Parameter. Default credentials are not recommended
```