### PR TITLE
Update End To End Tests To Fail Appropriately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Gemfile.lock
 /coverage
 /spec/aws_sample_templates/
+*.zip

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -7,7 +7,7 @@ download_and_scan_templates () {
   mkdir spec/aws_sample_templates || true
   pushd spec/aws_sample_templates
   curl -O https://s3-eu-west-1.amazonaws.com/cloudformation-examples-eu-west-1/AWSCloudFormation-samples.zip
-  rm *.template
+  rm -f *.template
   rm -rf aws-cloudformation-templates
   unzip AWSCloudFormation-samples.zip
   git clone https://github.com/awslabs/aws-cloudformation-templates.git

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -25,12 +25,10 @@ download_and_scan_templates () {
   # set +e because cfn_nag_scan failures are OK; Exceptions are not
   set +e
   cfn_nag_scan -i ./spec/aws_sample_templates 2>&1 >/dev/null | grep -A 25 Error
-  last_exit_code = $?
-  set -e
 
   # Since grep exits with a status code of 0 when it matches a pattern, if
   # the above command exits 0 then that means cfn_nag_scan threw an exception
-  if [ ${last_exit_code} -eq 0 ]; then
+  if [ $? -eq 0 ]; then
     echo -e "\nException found in cfn_nag_scan, exiting..\n"
     exit 1
   else

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -5,13 +5,10 @@ set -e
 # Function for downloading/scanning templates to check for exceptions
 download_and_scan_templates () {
   mkdir -p spec/aws_sample_templates || true
-  pushd spec/aws_sample_templates
-  curl -O https://s3-eu-west-1.amazonaws.com/cloudformation-examples-eu-west-1/AWSCloudFormation-samples.zip
-  rm -f *.template
-  rm -rf aws-cloudformation-templates
-  unzip AWSCloudFormation-samples.zip
-  git clone https://github.com/awslabs/aws-cloudformation-templates.git
-  popd
+  curl https://s3-eu-west-1.amazonaws.com/cloudformation-examples-eu-west-1/AWSCloudFormation-samples.zip -o spec/AWSCloudFormation-samples.zip
+  rm -rf spec/aws_sample_templates/*
+  unzip spec/AWSCloudFormation-samples.zip -d spec/aws_sample_templates
+  git clone https://github.com/awslabs/aws-cloudformation-templates.git spec/aws_sample_templates/aws-cloudformation-templates
   # Macros/SAM cause exceptions in cfn-model, removing these two directories
   # allow us to successfully lint everything else.
   rm -rf spec/aws_sample_templates/aws-cloudformation-templates/aws/services/CloudFormation/MacrosExamples

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -4,7 +4,7 @@ set -e
 
 # Function for downloading/scanning templates to check for exceptions
 download_and_scan_templates () {
-  mkdir spec/aws_sample_templates || true
+  mkdir -p spec/aws_sample_templates || true
   pushd spec/aws_sample_templates
   curl -O https://s3-eu-west-1.amazonaws.com/cloudformation-examples-eu-west-1/AWSCloudFormation-samples.zip
   rm -f *.template

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -22,7 +22,11 @@ download_and_scan_templates () {
   # 'Error' which incidates an exception was thrown. For whatever reason,
   # not every ruby exception/stacktrace contains the word 'exception'.
   echo -e "Linting sample templates..\n"
+  # unset -e because cfn_nag_scan failures are OK; Exceptions are not
+  unset -e
   cfn_nag_scan -i ./spec/aws_sample_templates 2>&1 >/dev/null | grep -A 25 Error
+
+  set -e
 
   # Since grep exits with a status code of 0 when it matches a pattern, if
   # the above command exits 0 then that means cfn_nag_scan threw an exception

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -25,12 +25,12 @@ download_and_scan_templates () {
   # set +e because cfn_nag_scan failures are OK; Exceptions are not
   set +e
   cfn_nag_scan -i ./spec/aws_sample_templates 2>&1 >/dev/null | grep -A 25 Error
-
+  last_exit_code = $?
   set -e
 
   # Since grep exits with a status code of 0 when it matches a pattern, if
   # the above command exits 0 then that means cfn_nag_scan threw an exception
-  if [ $? -eq 0 ]; then
+  if [ ${last_exit_code} -eq 0 ]; then
     echo -e "\nException found in cfn_nag_scan, exiting..\n"
     exit 1
   else

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -l
 
+set -e
+
 # Function for downloading/scanning templates to check for exceptions
 download_and_scan_templates () {
   mkdir spec/aws_sample_templates || true

--- a/scripts/setup_and_run_end_to_end_tests.sh
+++ b/scripts/setup_and_run_end_to_end_tests.sh
@@ -22,8 +22,8 @@ download_and_scan_templates () {
   # 'Error' which incidates an exception was thrown. For whatever reason,
   # not every ruby exception/stacktrace contains the word 'exception'.
   echo -e "Linting sample templates..\n"
-  # unset -e because cfn_nag_scan failures are OK; Exceptions are not
-  unset -e
+  # set +e because cfn_nag_scan failures are OK; Exceptions are not
+  set +e
   cfn_nag_scan -i ./spec/aws_sample_templates 2>&1 >/dev/null | grep -A 25 Error
 
   set -e


### PR DESCRIPTION
Adds the `set -e` flag to the bash script to appropriately fail the build on failing tests during the end to end run.