### PR TITLE
Push latest tag to Docker Hub

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -88,4 +88,6 @@ gem push cfn-nag-${GEM_VERSION}.gem
 
 docker build -t $docker_org/cfn_nag:${GEM_VERSION} .
 echo $docker_password | docker login -u $docker_user --password-stdin
+docker tag $docker_org/cfn_nag:latest $docker_org/cfn_nag:${GEM_VERSION}
 docker push $docker_org/cfn_nag:${GEM_VERSION}
+docker push $docker_org/cfn_nag:latest


### PR DESCRIPTION
Pushing the latest tag allows user to automatically use the latest version and use it by default instead of having to always specify a version to use.