### PR TITLE
Bugfix/account for false as string

### DIFF
--- a/lib/cfn-nag/custom_rules/KMSKeyRotationRule.rb
+++ b/lib/cfn-nag/custom_rules/KMSKeyRotationRule.rb
@@ -28,6 +28,6 @@ class KMSKeyRotationRule < BaseRule
   private
 
   def key_rotation_false_or_absent?(resource)
-    resource.enableKeyRotation.! || resource.enableKeyRotation.nil?
+    !truthy?(resource.enableKeyRotation)
   end
 end

--- a/spec/custom_rules/KMSKeyRotationRule_spec.rb
+++ b/spec/custom_rules/KMSKeyRotationRule_spec.rb
@@ -12,6 +12,14 @@ describe KMSKeyRotationRule do
         expect(actual_logical_resource_ids).to eq []
       end
     end
+    context 'when key rotation is explicitly set to true as a string' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_enable_key_rotation_true_string.json')
+        actual_logical_resource_ids = KMSKeyRotationRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
     context 'when key rotation is explicitly set to false' do
       it 'returns an offending logical resource id' do
         cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_enable_key_rotation_false.json')
@@ -20,7 +28,14 @@ describe KMSKeyRotationRule do
         expect(actual_logical_resource_ids).to eq ['myKeyRotationExplicitlyFalse']
       end
     end
+    context 'when key rotation is explicitly set to false as a string' do
+      it 'returns an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_enable_key_rotation_false_string.json')
+        actual_logical_resource_ids = KMSKeyRotationRule.new.audit_impl cfn_model
 
+        expect(actual_logical_resource_ids).to eq ['myKeyRotationExplicitlyFalseString']
+      end
+    end
     context 'when key rotation is absent' do
       it 'returns an offending logical resource id' do
         cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_enable_key_rotation_absent.json')

--- a/spec/test_templates/json/kms/kms_key_with_enable_key_rotation_false_string.json
+++ b/spec/test_templates/json/kms/kms_key_with_enable_key_rotation_false_string.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "myKeyRotationExplicitlyFalseString" : {
+      "Type" : "AWS::KMS::Key",
+      "Properties" : {
+        "Description" : "An example CMK",
+    		"EnableKeyRotation": "false",
+        "KeyPolicy" : {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::111122223333:root"},
+              "Action": "kms:*",
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+              "Action": [
+                "kms:Create*",
+                "kms:CancelKeyDeletion"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow use of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Bob" },
+              "Action": [
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/kms/kms_key_with_enable_key_rotation_true_string.json
+++ b/spec/test_templates/json/kms/kms_key_with_enable_key_rotation_true_string.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "myKeyRotationExplicitlyTrueString" : {
+      "Type" : "AWS::KMS::Key",
+      "Properties" : {
+        "Description" : "An example CMK",
+    		"EnableKeyRotation": "true",
+        "KeyPolicy" : {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::111122223333:root"},
+              "Action": "kms:*",
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+              "Action": [
+                "kms:Create*",
+                "kms:CancelKeyDeletion"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow use of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Bob" },
+              "Action": [
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
 This commit addresses an issue where key rotation may be set to false but as a string instead of a boolean, now it will be caught and flag a warning where previously it would not have.