### PR TITLE
Fail on not utilizing NoEcho for MasterUserPassword in AWS::Redshift::Cluster

### DIFF
--- a/lib/cfn-nag/custom_rules/RedshiftClusterMasterUserPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/RedshiftClusterMasterUserPasswordRule.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class RedshiftClusterMasterUserPasswordRule < BaseRule
+  def rule_text
+    'Redshift Cluster master user password must be Ref to NoEcho Parameter. ' \
+    'Default credentials are not recommended'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F35'
+  end
+
+  def audit_impl(cfn_model)
+    redshift_clusters = cfn_model.resources_by_type('AWS::Redshift::Cluster')
+    violating_redshift_clusters = redshift_clusters.select do |cluster|
+      if cluster.masterUserPassword.nil?
+        false
+      else
+        insecure_parameter?(cfn_model, cluster.masterUserPassword) ||
+          insecure_string_or_dynamic_reference?(cfn_model, cluster.masterUserPassword)
+      end
+    end
+
+    violating_redshift_clusters.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/RedshiftClusterMasterUserPasswordRule'
+
+describe RedshiftClusterMasterUserPasswordRule, :rule do
+  context 'Redshift Cluster without master user password set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/redshift_cluster_no_master_user_password.yml'
+      )
+
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster with parameter master user password with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_parameter_noecho.yml'
+      )
+
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster with literal master user password in plaintext' do
+    it 'returns offending logical resource id for offending Redshift Cluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_plaintext.yml'
+      )
+
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[RedshiftCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster with parameter master user password with NoEcho ' \
+    'that has Default value' do
+    it 'returns offending logical resource id for offending Redshift Cluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_parameter_noecho_with_default.yml'
+      )
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[RedshiftCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster master user password from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_secrets_manager.yml'
+      )
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster master user password from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_ssm-secure.yml'
+      )
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Redshift Cluster master user password from Systems Manager' do
+    it 'returns offending logical resource id for offending Redshift Cluster' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/redshift_cluster_master_user_password_ssm.yml'
+      )
+      actual_logical_resource_ids =
+        RedshiftClusterMasterUserPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[RedshiftCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho.yml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  RedshiftClusterMasterUserPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: !Ref RedshiftClusterMasterUserPassword
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho.yml
@@ -12,4 +12,3 @@ Resources:
       MasterUserPassword: !Ref RedshiftClusterMasterUserPassword
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho_with_default.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho_with_default.yml
@@ -13,4 +13,3 @@ Resources:
       MasterUserPassword: !Ref RedshiftClusterMasterUserPassword
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho_with_default.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_parameter_noecho_with_default.yml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  RedshiftClusterMasterUserPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: !Ref RedshiftClusterMasterUserPassword
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_plaintext.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_plaintext.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: b@dP@$sW0rD
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_plaintext.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_plaintext.yml
@@ -8,4 +8,3 @@ Resources:
       MasterUserPassword: b@dP@$sW0rD
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_secrets_manager.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_secrets_manager.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: '{{resolve:secretsmanager:/redshift/cluster/masteruserpassword:SecretString:password}}'
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_secrets_manager.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_secrets_manager.yml
@@ -8,4 +8,3 @@ Resources:
       MasterUserPassword: '{{resolve:secretsmanager:/redshift/cluster/masteruserpassword:SecretString:password}}'
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm-secure.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm-secure.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm-secure.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm-secure.yml
@@ -8,4 +8,3 @@ Resources:
       MasterUserPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUserPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_master_user_password_ssm.yml
@@ -8,4 +8,3 @@ Resources:
       MasterUserPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
       MasterUsername: admin
       NodeType: dc2.large
-  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_no_master_user_password.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_no_master_user_password.yml
@@ -1,0 +1,10 @@
+---
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterType: single-node
+      DBName: foobar
+      MasterUsername: admin
+      NodeType: dc2.large
+  

--- a/spec/test_templates/yaml/redshift_cluster/redshift_cluster_no_master_user_password.yml
+++ b/spec/test_templates/yaml/redshift_cluster/redshift_cluster_no_master_user_password.yml
@@ -7,4 +7,3 @@ Resources:
       DBName: foobar
       MasterUsername: admin
       NodeType: dc2.large
-  


### PR DESCRIPTION
This takes care of Issue #54 

This creates a new Failing rule whenever the MasterUserPassword for Redshift Cluster is set in plaintext either in the resource itself, or as a default from a parameter. If MasterUserPassword for Redshift Cluster is specified, then it needs to be set as a parameter with NoEcho.

```
F35 Redshift Cluster master user password must be Ref to NoEcho Parameter. Default credentials are not recommended
```