### PR TITLE
Fail on not utilizing NoEcho for Password in AWS::DirectoryService::MicrosoftAD

### DIFF
--- a/lib/cfn-nag/custom_rules/DirectoryServiceMicrosoftADPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/DirectoryServiceMicrosoftADPasswordRule.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+# Rule class to fail on DirectoryService::MicrosoftAD password in template
+class DirectoryServiceMicrosoftADPasswordRule < BaseRule
+  def rule_text
+    'DirectoryService::MicrosoftAD password must be Ref to NoEcho Parameter. ' \
+    'Default credentials are not recommended'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F36'
+  end
+
+  def audit_impl(cfn_model)
+    violating_ad = cfn_model.resources_by_type('AWS::DirectoryService::MicrosoftAD')
+                            .select do |ad|
+      if ad.password.nil?
+        false
+      else
+        insecure_parameter?(cfn_model, ad.password) ||
+          insecure_string_or_dynamic_reference?(cfn_model, ad.password)
+      end
+    end
+    violating_ad.map(&:logical_resource_id)
+  end
+end

--- a/lib/cfn-nag/custom_rules/DirectoryServiceMicrosoftADPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/DirectoryServiceMicrosoftADPasswordRule.rb
@@ -8,8 +8,8 @@ require_relative 'base'
 # Rule class to fail on DirectoryService::MicrosoftAD password in template
 class DirectoryServiceMicrosoftADPasswordRule < BaseRule
   def rule_text
-    'DirectoryService::MicrosoftAD password must be Ref to NoEcho Parameter. ' \
-    'Default credentials are not recommended'
+    'Directory Service Microsoft AD must not be a plaintext string or a ' \
+    'Ref to a NoEcho Parameter with a Default value.'
   end
 
   def rule_type

--- a/spec/custom_rules/DirectoryServiceMicrosoftADPasswordRule_spec.rb
+++ b/spec/custom_rules/DirectoryServiceMicrosoftADPasswordRule_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/DirectoryServiceMicrosoftADPasswordRule'
+
+describe DirectoryServiceMicrosoftADPasswordRule, :rule do
+  context 'Directory Service Microsoft AD without password set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_no_password.yml'
+      )
+
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD with parameter password with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_parameter_noecho.yml'
+      )
+
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD with literal password in plaintext' do
+    it 'returns offending logical resource id for offending ' \
+      'Directory Service Microsoft AD' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_plaintext.yml'
+      )
+
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MicrosoftAD]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD with parameter password with ' \
+    'NoEcho that has Default value' do
+    it 'returns offending logical resource id for offending ' \
+      'Directory Service Microsoft AD' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_parameter_noecho_with_default.yml'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MicrosoftAD]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD password from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_secrets_manager.yml'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD password from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_ssm-secure.yml'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Directory Service Microsoft AD password from Systems Manager' do
+    it 'returns offending logical resource id for offending ' \
+      'Directory Service Microsoft AD' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/directory_service_microsoft_ad/' \
+        'directory_service_microsoft_ad_password_ssm.yml'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceMicrosoftADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MicrosoftAD]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_no_password.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_no_password.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_parameter_noecho.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_parameter_noecho.yml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  MicrosoftADPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: !Ref MicrosoftADPassword
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_parameter_noecho_with_default.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_parameter_noecho_with_default.yml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  MicrosoftADPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: !Ref MicrosoftADPassword
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_plaintext.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_plaintext.yml
@@ -1,0 +1,12 @@
+---
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: b@dP@$sW0rD
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_secrets_manager.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_secrets_manager.yml
@@ -1,0 +1,12 @@
+---
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: '{{resolve:secretsmanager:/rds/db_cluster/masteruserpassword:SecretString:password}}'
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_secrets_manager.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_secrets_manager.yml
@@ -4,7 +4,7 @@ Resources:
     Type: AWS::DirectoryService::MicrosoftAD
     Properties:
       Name: microsoftad.foobar.com
-      Password: '{{resolve:secretsmanager:/rds/db_cluster/masteruserpassword:SecretString:password}}'
+      Password: '{{resolve:secretsmanager:/directory_service/microsoft_ad/password:SecretString:password}}'
       VpcSettings:
         SubnetIds:
           - subnet-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_ssm-secure.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_ssm-secure.yml
@@ -1,0 +1,12 @@
+---
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar

--- a/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_ssm.yml
+++ b/spec/test_templates/yaml/directory_service_microsoft_ad/directory_service_microsoft_ad_password_ssm.yml
@@ -1,0 +1,12 @@
+---
+Resources:
+  MicrosoftAD:
+    Type: AWS::DirectoryService::MicrosoftAD
+    Properties:
+      Name: microsoftad.foobar.com
+      Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+      VpcSettings:
+        SubnetIds:
+          - subnet-foobar
+          - subnet-foobaz
+        VpcId: vpc-foobar


### PR DESCRIPTION
This takes care of Issue #66 

This creates a new Failing rule whenever the Password for Directory Service Microsoft Active Directory is set in plaintext either in the resource itself, or as a default from a parameter. If Password for Directory Service Microsoft Active Directory is specified, then it needs to be set as a parameter with NoEcho.

```
F36 DirectoryService::MicrosoftAD password must be Ref to NoEcho Parameter. Default credentials are not recommended
```