### PR TITLE
Fail on not utilizing NoEcho for Password in AWS::DMS::Endpoint

### DIFF
--- a/lib/cfn-nag/custom_rules/DMSEndpointPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/DMSEndpointPasswordRule.rb
@@ -7,8 +7,8 @@ require_relative 'base'
 
 class DMSEndpointPasswordRule < BaseRule
   def rule_text
-    'DMS Endpoint password must be Ref to NoEcho Parameter. ' \
-    'Default credentials are not recommended'
+    'DMS Endpoint must not be a plaintext string or a Ref to a NoEcho ' \
+    'Parameter with a Default value.'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/DMSEndpointPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/DMSEndpointPasswordRule.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class DMSEndpointPasswordRule < BaseRule
+  def rule_text
+    'DMS Endpoint password must be Ref to NoEcho Parameter. ' \
+    'Default credentials are not recommended'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F37'
+  end
+
+  def audit_impl(cfn_model)
+    dms_endpoints = cfn_model.resources_by_type('AWS::DMS::Endpoint')
+    violating_dms_endpoints = dms_endpoints.select do |endpoint|
+      if endpoint.password.nil?
+        false
+      else
+        insecure_parameter?(cfn_model, endpoint.password) ||
+          insecure_string_or_dynamic_reference?(cfn_model, endpoint.password)
+      end
+    end
+
+    violating_dms_endpoints.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/DMSEndpointPasswordRule_spec.rb
+++ b/spec/custom_rules/DMSEndpointPasswordRule_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/DMSEndpointPasswordRule'
+
+describe DMSEndpointPasswordRule, :rule do
+  context 'DMS Endpoint without password set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_no_password.yml'
+      )
+
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint with parameter password with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_password_parameter_noecho.yml'
+      )
+
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint with literal password in plaintext' do
+    it 'returns offending logical resource id for offending DMS Endpoint' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_password_plaintext.yml'
+      )
+
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DMSEndpoint]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint with parameter password with NoEcho ' \
+    'that has Default value' do
+    it 'returns offending logical resource id for offending DMS Endpoint' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/' \
+        'dms_endpoint_password_parameter_noecho_with_default.yml'
+      )
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DMSEndpoint]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint password from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_password_secrets_manager.yml'
+      )
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint password from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_password_ssm-secure.yml'
+      )
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DMS Endpoint password from Systems Manager' do
+    it 'returns offending logical resource id for offending DMS Endpoint' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dms_endpoint/dms_endpoint_password_ssm.yml'
+      )
+      actual_logical_resource_ids =
+        DMSEndpointPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DMSEndpoint]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_no_password.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_no_password.yml
@@ -1,0 +1,10 @@
+---
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_parameter_noecho.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_parameter_noecho.yml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  DMSEndpointPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: !Ref DMSEndpointPassword
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_parameter_noecho_with_default.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_parameter_noecho_with_default.yml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  DMSEndpointPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: !Ref DMSEndpointPassword
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_plaintext.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_plaintext.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: b@dP@$sW0rD
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_secrets_manager.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_secrets_manager.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: '{{resolve:secretsmanager:/dms/endpoint/password:SecretString:password}}'
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_ssm-secure.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_ssm-secure.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      Port: 3306
+      ServerName: foobar
+      Username: admin

--- a/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_ssm.yml
+++ b/spec/test_templates/yaml/dms_endpoint/dms_endpoint_password_ssm.yml
@@ -1,0 +1,11 @@
+---
+Resources:
+  DMSEndpoint:
+    Type: AWS::DMS::Endpoint
+    Properties:
+      EngineName: aurora
+      EndpointType: source
+      Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+      Port: 3306
+      ServerName: foobar
+      Username: admin


### PR DESCRIPTION
This takes care of Issue #64 

This creates a new Failing rule whenever the Password for DMS Endpoint is set in plaintext either in the resource itself, or as a default from a parameter. If Password for DMS Endpoint is specified, then it needs to be set as a parameter with NoEcho.

```
F37 DMS Endpoint password must be Ref to NoEcho Parameter. Default credentials are not recommended
```