### PR TITLE
Add Dynamic Reference checks for AWS::DirectoryService::SimpleAD Password

### DIFF
--- a/spec/custom_rules/DirectoryServiceSimpleADPasswordRule_spec.rb
+++ b/spec/custom_rules/DirectoryServiceSimpleADPasswordRule_spec.rb
@@ -5,10 +5,13 @@ require 'cfn-nag/custom_rules/DirectoryServiceSimpleADPasswordRule'
 describe DirectoryServiceSimpleADPasswordRule, :rule do
 
   context 'Good SimpleAD with parameter, no echo true, and no default' do
-    it 'returns offending logical resource id' do
-      cfn_model = CfnParser.new.parse read_test_template('json/simple_ad/good_no_echo_no_default.json')
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/good_no_echo_no_default.json'
+      )
 
-      actual_logical_resource_ids = DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
       expected_logical_resource_ids = %w[]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
@@ -17,9 +20,12 @@ describe DirectoryServiceSimpleADPasswordRule, :rule do
 
   context 'Bad SimpleAD with default password' do
     it 'returns offending logical resource id' do
-      cfn_model = CfnParser.new.parse read_test_template('json/simple_ad/with_default_password.json')
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/with_default_password.json'
+      )
 
-      actual_logical_resource_ids = DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
       expected_logical_resource_ids = %w[SimpleAD]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
@@ -28,9 +34,12 @@ describe DirectoryServiceSimpleADPasswordRule, :rule do
 
   context 'Bad SimpleAD with noecho parameter but specifies password' do
     it 'returns offending logical resource id' do
-      cfn_model = CfnParser.new.parse read_test_template('json/simple_ad/with_default_password_and_no_echo.json')
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/with_default_password_and_no_echo.json'
+      )
 
-      actual_logical_resource_ids = DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
       expected_logical_resource_ids = %w[SimpleAD]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
@@ -39,9 +48,12 @@ describe DirectoryServiceSimpleADPasswordRule, :rule do
 
   context 'Bad SimpleAD with parameter noecho set to false' do
     it 'returns offending logical resource id' do
-      cfn_model = CfnParser.new.parse read_test_template('json/simple_ad/with_no_echo_false.json')
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/with_no_echo_false.json'
+      )
 
-      actual_logical_resource_ids = DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
       expected_logical_resource_ids = %w[SimpleAD]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
@@ -50,9 +62,51 @@ describe DirectoryServiceSimpleADPasswordRule, :rule do
 
   context 'Bad SimpleAD without password parameter' do
     it 'returns offending logical resource id' do
-      cfn_model = CfnParser.new.parse read_test_template('json/simple_ad/without_parameter.json')
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/without_parameter.json'
+      )
 
-      actual_logical_resource_ids = DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[SimpleAD]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Good SimpleAD with password from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/simple_ad_password_secrets_manager.json'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Good SimpleAD with password from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/simple_ad_password_ssm-secure.json'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Good SimpleAD with password from Systems Manager' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'json/simple_ad/simple_ad_password_ssm.json'
+      )
+      actual_logical_resource_ids =
+        DirectoryServiceSimpleADPasswordRule.new.audit_impl cfn_model
       expected_logical_resource_ids = %w[SimpleAD]
 
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids

--- a/spec/test_templates/json/simple_ad/simple_ad_password_secrets_manager.json
+++ b/spec/test_templates/json/simple_ad/simple_ad_password_secrets_manager.json
@@ -1,0 +1,18 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "SimpleAD template with password parameter as Secrets Manager Dynamic Reference",
+  "Resources" : {
+    "SimpleAD": {
+      "Type" : "AWS::DirectoryService::SimpleAD",
+      "Properties" : {
+        "Name" : "CFNNagTestSimpleAD",
+        "Password" : "{{resolve:secretsmanager:/directory_service/simple_ad/password:SecretString:password}}",
+        "Size" : "Small",
+        "VpcSettings" : {
+          "SubnetIds": [ "us-east-1a", "us-east-1b", "us-east-1c" ],
+          "VpcId" : "default"
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/simple_ad/simple_ad_password_ssm-secure.json
+++ b/spec/test_templates/json/simple_ad/simple_ad_password_ssm-secure.json
@@ -1,0 +1,18 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "SimpleAD template with password parameter as Secure Systems Manager Dynamic Reference",
+  "Resources" : {
+    "SimpleAD": {
+      "Type" : "AWS::DirectoryService::SimpleAD",
+      "Properties" : {
+        "Name" : "CFNNagTestSimpleAD",
+        "Password" : "{{resolve:ssm-secure:SecureSecretString:1}}",
+        "Size" : "Small",
+        "VpcSettings" : {
+          "SubnetIds": [ "us-east-1a", "us-east-1b", "us-east-1c" ],
+          "VpcId" : "default"
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/simple_ad/simple_ad_password_ssm.json
+++ b/spec/test_templates/json/simple_ad/simple_ad_password_ssm.json
@@ -1,0 +1,18 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Description" : "SimpleAD template with password parameter as Systems Manager Dynamic Reference",
+  "Resources" : {
+    "SimpleAD": {
+      "Type" : "AWS::DirectoryService::SimpleAD",
+      "Properties" : {
+        "Name" : "CFNNagTestSimpleAD",
+        "Password" : "{{resolve:ssm:UnsecureSecretString:1}}",
+        "Size" : "Small",
+        "VpcSettings" : {
+          "SubnetIds": [ "us-east-1a", "us-east-1b", "us-east-1c" ],
+          "VpcId" : "default"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added 3 additional tests to check the usage against Dynamic Reference strings using Secrets Manager, Secure Systems Manager, & System Manager.

Also adjust code layout a bit to shorten line lengths.