### PR TITLE
fix dockerfile when gemfile.lock is not present

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -4,8 +4,6 @@ ENV APP_ROOT=/usr/src/app
 
 RUN gem install rubocop
 
-COPY Gemfile ${APP_ROOT}/
-COPY Gemfile.lock ${APP_ROOT}/
-RUN bundle install
+COPY Gemfile* ${APP_ROOT}/
 
-COPY . ${APP_ROOT}
+RUN bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ task :spec do
   end
 end
 
-desc 'Build the local Docker iamge for development/testing'
+desc 'Build the local Docker image for development/testing'
 task :build_docker_dev do
   sh 'docker build --file Dockerfile-dev --rm --tag cfn-nag-dev .'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,13 +31,13 @@ task :build_docker_dev do
 end
 
 namespace 'test' do
-  desc 'Run all rspec tests'
+  desc 'Run all rspec tests (via docker)'
   task :all do
     ensure_local_dev_image
     sh "#{docker_run_prefix} ./scripts/rspec.sh"
   end
 
-  desc 'Run the end-to-end rspec tests'
+  desc 'Run the end-to-end rspec tests (via docker)'
   task :e2e do
     ensure_local_dev_image
     sh "#{docker_run_prefix} ./scripts/setup_and_run_end_to_end_tests.sh"


### PR DESCRIPTION
This fixes the Dockerfile-dev for when the Gemfile.lock file is not present. Such as when a fresh copy of the repo is checked out.