### PR TITLE
Feature/adjust password base rule to work with sub properties

### DIFF
--- a/lib/cfn-nag/custom_rules/AmplifyAppBasicAuthConfigPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/AmplifyAppBasicAuthConfigPasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class AmplifyAppBasicAuthConfigPasswordRule < PasswordBaseRule
+  def rule_text
+    'Amplify App BasicAuthConfig Password must not be a plaintext string ' \
+    'or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F50'
+  end
+
+  def resource_type
+    'AWS::Amplify::App'
+  end
+
+  def password_property
+    :basicAuthConfig
+  end
+
+  def sub_property_name
+    'Password'
+  end
+end

--- a/lib/cfn-nag/custom_rules/password_base_rule.rb
+++ b/lib/cfn-nag/custom_rules/password_base_rule.rb
@@ -24,7 +24,7 @@ class PasswordBaseRule < BaseRule
         false
       else
         verify_insecure_string_and_parameter(
-          cfn_model,resource, password_property, sub_property_name
+          cfn_model, resource, password_property, sub_property_name
         )
       end
     end

--- a/lib/cfn-nag/custom_rules/password_base_rule.rb
+++ b/lib/cfn-nag/custom_rules/password_base_rule.rb
@@ -14,19 +14,49 @@ class PasswordBaseRule < BaseRule
     raise 'must implement in subclass'
   end
 
+  def sub_property_name; end
+
   def audit_impl(cfn_model)
     resources = cfn_model.resources_by_type(resource_type)
 
     violating_resources = resources.select do |resource|
-      if resource.send(password_property).nil?
+      if verify_parameter_exists(resource, password_property, sub_property_name)
         false
       else
-        insecure_parameter?(cfn_model, resource.send(password_property)) ||
-          insecure_string_or_dynamic_reference?(cfn_model,
-                                                resource.send(password_property))
+        verify_insecure_string_and_parameter(
+          cfn_model,resource, password_property, sub_property_name
+        )
       end
     end
 
     violating_resources.map(&:logical_resource_id)
+  end
+end
+
+private
+
+def verify_parameter_exists(resource, password_property, sub_property_name)
+  if sub_property_name.nil?
+    resource.send(password_property).nil?
+  else
+    resource.send(password_property)[sub_property_name].nil?
+  end
+end
+
+def verify_insecure_string_and_parameter(
+  cfn_model, resource, password_property, sub_property_name
+)
+  if sub_property_name.nil?
+    insecure_parameter?(cfn_model, resource.send(password_property)) ||
+      insecure_string_or_dynamic_reference?(
+        cfn_model, resource.send(password_property)
+      )
+  else
+    insecure_parameter?(
+      cfn_model, resource.send(password_property)[sub_property_name]
+    ) ||
+      insecure_string_or_dynamic_reference?(
+        cfn_model, resource.send(password_property)[sub_property_name]
+      )
   end
 end

--- a/spec/custom_rules/AmplifyAppBasicAuthConfigPasswordRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppBasicAuthConfigPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::Amplify::App'
+password_property = 'BasicAuthConfig'
+sub_property_name = 'Password'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name, test_template_type,
+                 test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'password_rule_spec_helper'
 require 'cfn-model'
 
-password_property = 'MasterUserPassword'
 resource_type = 'AWS::RDS::DBCluster'
+password_property = 'MasterUserPassword'
+sub_property_name = nil
 test_template_type = 'yaml'
 
-require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property)}"
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
 
-describe Object.const_get(rule_name(resource_type, password_property)), :rule do
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
   # Creates dynamic set of contexts based on the password_rule_test_sets hash
   password_rule_test_sets.each do |test_description, desired_test_result|
     context "#{resource_type} #{password_property} #{test_description}" do
       it context_return_value(desired_test_result) do
-        run_test(resource_type, password_property, test_template_type,
+        run_test(resource_type, password_property, sub_property_name, test_template_type,
                  test_description, desired_test_result)
       end
     end

--- a/spec/custom_rules/RDSDBInstanceMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBInstanceMasterUserPasswordRule_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'password_rule_spec_helper'
 require 'cfn-model'
 
-password_property = 'MasterUserPassword'
 resource_type = 'AWS::RDS::DBInstance'
+password_property = 'MasterUserPassword'
+sub_property_name = nil
 test_template_type = 'yaml'
 
-require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property)}"
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
 
-describe Object.const_get(rule_name(resource_type, password_property)), :rule do
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
   # Creates dynamic set of contexts based on the password_rule_test_sets hash
   password_rule_test_sets.each do |test_description, desired_test_result|
     context "#{resource_type} #{password_property} #{test_description}" do
       it context_return_value(desired_test_result) do
-        run_test(resource_type, password_property, test_template_type,
+        run_test(resource_type, password_property, sub_property_name, test_template_type,
                  test_description, desired_test_result)
       end
     end

--- a/spec/custom_rules/RDSDBInstanceMasterUsernameRule_spec.rb
+++ b/spec/custom_rules/RDSDBInstanceMasterUsernameRule_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'password_rule_spec_helper'
 require 'cfn-model'
 
-password_property = 'MasterUsername'
 resource_type = 'AWS::RDS::DBInstance'
+password_property = 'MasterUsername'
+sub_property_name = nil
 test_template_type = 'yaml'
 
-require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property)}"
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
 
-describe Object.const_get(rule_name(resource_type, password_property)), :rule do
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
   # Creates dynamic set of contexts based on the password_rule_test_sets hash
   password_rule_test_sets.each do |test_description, desired_test_result|
     context "#{resource_type} #{password_property} #{test_description}" do
       it context_return_value(desired_test_result) do
-        run_test(resource_type, password_property, test_template_type,
+        run_test(resource_type, password_property, sub_property_name, test_template_type,
                  test_description, desired_test_result)
       end
     end

--- a/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'password_rule_spec_helper'
 require 'cfn-model'
 
+resource_type = 'AWS::Redshift::Cluster'
 password_property = 'MasterUserPassword'
-resource_type = 'AWS::RDS::DBCluster'
+sub_property_name = nil
 test_template_type = 'yaml'
 
-require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property)}"
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
 
-describe Object.const_get(rule_name(resource_type, password_property)), :rule do
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
   # Creates dynamic set of contexts based on the password_rule_test_sets hash
   password_rule_test_sets.each do |test_description, desired_test_result|
     context "#{resource_type} #{password_property} #{test_description}" do
       it context_return_value(desired_test_result) do
-        run_test(resource_type, password_property, test_template_type,
+        run_test(resource_type, password_property, sub_property_name, test_template_type,
                  test_description, desired_test_result)
       end
     end

--- a/spec/custom_rules/password_base_rule_spec.rb
+++ b/spec/custom_rules/password_base_rule_spec.rb
@@ -63,7 +63,6 @@ describe PasswordBaseRule do
 
       expect(base_rule).to \
         receive(:password_property).and_return(:masterUserPassword,
-                                               :masterUserPassword,
                                                :masterUserPassword)
       expect(base_rule).to \
         receive(:resource_type).and_return('AWS::Redshift::Cluster')
@@ -81,7 +80,6 @@ describe PasswordBaseRule do
 
       expect(base_rule).to \
         receive(:password_property).and_return(:masterUserPassword,
-                                               :masterUserPassword,
                                                :masterUserPassword)
       expect(base_rule).to \
         receive(:resource_type).and_return('AWS::Redshift::Cluster')
@@ -121,7 +119,6 @@ describe PasswordBaseRule do
 
       expect(base_rule).to \
         receive(:password_property).and_return(:masterUserPassword,
-                                               :masterUserPassword,
                                                :masterUserPassword)
       expect(base_rule).to \
         receive(:resource_type).and_return('AWS::Redshift::Cluster')
@@ -139,7 +136,6 @@ describe PasswordBaseRule do
 
       expect(base_rule).to \
         receive(:password_property).and_return(:masterUserPassword,
-                                               :masterUserPassword,
                                                :masterUserPassword)
       expect(base_rule).to \
         receive(:resource_type).and_return('AWS::Redshift::Cluster')
@@ -157,7 +153,6 @@ describe PasswordBaseRule do
 
       expect(base_rule).to \
         receive(:password_property).and_return(:masterUserPassword,
-                                               :masterUserPassword,
                                                :masterUserPassword)
       expect(base_rule).to \
         receive(:resource_type).and_return('AWS::Redshift::Cluster')

--- a/spec/password_rule_spec_helper.rb
+++ b/spec/password_rule_spec_helper.rb
@@ -39,7 +39,18 @@ def context_return_value(desired_test_result)
 end
 
 # Creates the string name for the rule
-def rule_name(resource_type, password_property)
+def rule_name(resource_type, password_property, sub_property_name)
+  if sub_property_name.nil?
+    _nil_sub_property_name_rule_name(resource_type, password_property)
+  else
+    _not_nil_sub_property_name_rule_name(
+      resource_type, password_property, sub_property_name
+    )
+  end
+end
+
+# Creates the logic for the rule name if sub_property_name is nil
+def _nil_sub_property_name_rule_name(resource_type, password_property)
   [
     resource_type.sub('AWS', '').gsub('::', ''),
     password_property,
@@ -47,14 +58,59 @@ def rule_name(resource_type, password_property)
   ].join
 end
 
+# Creates the logic for the rule name if sub_property_name is present
+def _not_nil_sub_property_name_rule_name(
+  resource_type, password_property, sub_property_name
+)
+  [
+    resource_type.sub('AWS', '').gsub('::', ''),
+    password_property,
+    sub_property_name,
+    'Rule'
+  ].join
+end
+
 # Creates full file path string
-def file_path(resource_type,
-              test_template_type,
-              password_property,
-              test_description)
+def file_path(
+  resource_type, test_template_type, password_property, sub_property_name,
+  test_description
+)
+  if sub_property_name.nil?
+    _nil_sub_property_name_file_path(
+      resource_type, test_template_type, password_property, test_description
+    )
+  else
+    _not_nil_sub_property_name_file_path(
+      resource_type, test_template_type, password_property,
+      sub_property_name, test_description
+    )
+  end
+end
+
+# Creates the logic for the file path if sub_property_name is nil
+def _nil_sub_property_name_file_path(
+  resource_type, test_template_type, password_property, test_description
+)
   [
     file_path_prefix(resource_type, test_template_type),
     password_property.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
+    '_',
+    test_description.to_s.gsub(' ', '_').downcase,
+    '.',
+    test_template_type
+  ].join
+end
+
+# Creates the logic for the file path if sub_property_name is present
+def _not_nil_sub_property_name_file_path(
+  resource_type, test_template_type, password_property,
+  sub_property_name, test_description
+)
+  [
+    file_path_prefix(resource_type, test_template_type),
+    password_property.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
+    '_',
+    sub_property_name.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
     '_',
     test_description.to_s.gsub(' ', '_').downcase,
     '.',
@@ -75,16 +131,17 @@ def expected_logical_resource_ids(desired_test_result, resource_type)
 end
 
 # Run the spec test
-def run_test(resource_type,
-             password_property,
-             test_template_type,
-             test_description,
-             desired_test_result)
+def run_test(
+  resource_type, password_property, sub_property_name, test_template_type,
+  test_description, desired_test_result
+)
   cfn_model =
-    CfnParser.new.parse read_test_template(file_path(resource_type,
-                                                     test_template_type,
-                                                     password_property,
-                                                     test_description))
+    CfnParser.new.parse read_test_template(
+      file_path(
+        resource_type, test_template_type, password_property,
+        sub_property_name, test_description
+      )
+    )
 
   actual_logical_resource_ids = described_class.new.audit_impl cfn_model
 

--- a/spec/password_rule_spec_helper_spec.rb
+++ b/spec/password_rule_spec_helper_spec.rb
@@ -59,19 +59,56 @@ describe 'password_rule_spec_helper' do
     end
   end
 
-  context 'rule_name' do
+  context 'rule_name with sub_property_name set' do
+    before(:each) do
+      @sub_property_name = 'Qux'
+    end
     it 'renders rule name' do
-      actual_aggregate_results = rule_name(@resource_type, @password_property)
+      actual_aggregate_results = rule_name(
+        @resource_type, @password_property, @sub_property_name
+      )
+      expect(actual_aggregate_results).to eq 'FooBarBazQuxRule'
+    end
+  end
+
+  context 'rule_name with no sub_property_name set' do
+    before(:each) do
+      @sub_property_name = nil
+    end
+    it 'renders rule name' do
+      actual_aggregate_results = rule_name(
+        @resource_type, @password_property, @sub_property_name
+      )
       expect(actual_aggregate_results).to eq 'FooBarBazRule'
     end
   end
 
-  context 'file_path' do
+  context 'file_path with sub_property_name set' do
+    before(:each) do
+      @sub_property_name = 'Qux'
+    end
     it 'renders full test template file path' do
       actual_aggregate_results =
         file_path(@resource_type,
                   @test_template_type,
                   @password_property,
+                  @sub_property_name,
+                  'test template name')
+      expect(actual_aggregate_results).to eq \
+        'yaml/foo_bar/foo_bar_baz_qux_test_template_name.yaml'
+    end
+  end
+
+  context 'file_path with no sub_property_name set' do
+    before(:each) do
+      @sub_property_name = nil
+    end
+    it 'renders full test template file path' do
+      actual_aggregate_results =
+        file_path(@resource_type,
+                  @test_template_type,
+                  @password_property,
+                  @sub_property_name,
                   'test template name')
       expect(actual_aggregate_results).to eq \
         'yaml/foo_bar/foo_bar_baz_test_template_name.yaml'

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: b@dP@$sW0rD
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_secrets_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: '{{resolve:secretsmanager:/amplify/app/basicauthconfig_password:SecretString:password}}'
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_secure_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_from_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_not_set.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_not_set.yaml
@@ -1,0 +1,8 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: False
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Parameters:
+  AmplifyAppBasicAuthConfigPassword:
+    Type: String
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: !Ref AmplifyAppBasicAuthConfigPassword
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_with_noecho.yaml
@@ -1,0 +1,14 @@
+---
+Parameters:
+  AmplifyAppBasicAuthConfigPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: !Ref AmplifyAppBasicAuthConfigPassword
+        Username: admin
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_basic_auth_config_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  AmplifyAppBasicAuthConfigPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      BasicAuthConfig:
+        EnableBasicAuth: True
+        Password: !Ref AmplifyAppBasicAuthConfigPassword
+        Username: admin
+      Name: foobar


### PR DESCRIPTION
Takes care of #254  & assists with #253 

To go along with the new password base rule and spec helper that were recently added, this is needed to allow the addition of Resource/Property items that utilize a password like sub-property.
```
AWS::Amplify::App.BasicAuthConfig
  Password
```

Now to go along with the password base rule you can add an additional variable to define a sub-property if desired. Then in the spec that you create from the helper you need to add a new variable and specify nil or a value.

Examples:
In a new password rule that needs to define a sub-property
```
  def resource_type
    'AWS::Amplify::App'
  end

  def password_property
    :basicAuthConfig
  end

  def sub_property_name
    'Password'
  end
```

In a new password rule that doesn't need to define a sub-property
```
  def resource_type
    'AWS::Redshift::Cluster'
  end

  def password_property
    :masterUserPassword
  end
```

In a new password rule spec that needs to define a sub-property
```
resource_type = 'AWS::Amplify::App'
password_property = 'BasicAuthConfig'
sub_property_name = 'Password'
test_template_type = 'yaml'
```

In a new password rule spec that doesn't need to define a sub-property
```
resource_type = 'AWS::Redshift::Cluster'
password_property = 'MasterUserPassword'
sub_property_name = nil
test_template_type = 'yaml'
```

I've added in a new Rule and Spec for `AWS::Amplify::App.BasicAuthConfig > Password`. I've also adjusted the existing Specs that are already utilizing the `password_rule_spec_helper` so that the new `sub_property_name` can be defined and used there.