### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5-alpine3.9@sha256:f33782620b363575ad95d19d0f0f07f7d197e9ccfee51f20df39dd33d408cdb4
 
-MAINTAINER eric.kascic@stelligent.com
+LABEL org.opencontainers.image.authors="eric.kascic@stelligent.com"
 
 RUN gem install cfn-nag
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5-alpine3.9@sha256:f33782620b363575ad95d19d0f0f07f7d197e9ccfee51f20df39dd33d408cdb4
 
 MAINTAINER eric.kascic@stelligent.com
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5-alpine3.9@sha256:f33782620b363575ad95d19d0f0f07f7d197e9ccfee51f20df39dd33d408cdb4
 
 ADD . /
 RUN gem install bundler

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 FROM ruby:2.5-alpine3.9@sha256:f33782620b363575ad95d19d0f0f07f7d197e9ccfee51f20df39dd33d408cdb4
 
-ADD . /
+COPY . /
 RUN gem install bundler
 RUN bundle install


### PR DESCRIPTION
A couple of minor stylistic changes but the main change is a switch to an alpine-based base image for ruby which saves almost 800MB in resulting image size.