### PR TITLE
'gem build' command fixed.

### DIFF
--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -2,5 +2,6 @@
 
 echo "Installing cfn_nag from local source"
 gem uninstall cfn-nag -x
-GEM_VERSION=0.0.01 gem build cfn-nag.gemspec
+GEM_VERSION=0.0.01
+gem build cfn-nag.gemspec
 gem install cfn-nag-0.0.01.gem --no-document


### PR DESCRIPTION
The 'gem build' command appears to have accidentally been included in the GEM_VERSION environment variable.