### PR TITLE
#86 install cfn_nag using brew on Mac and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ gem install cfn-nag
 ```
 
 ## Brew Install
-On MacOS or Linux (tested on ubuntu) install with brew
+On MacOS or Linux you can alternatively install with brew
 
 ```bash
-brew tap stelligent/homebrew-tap
-brew install cfn-nag
+brew install ruby brew-gem
+brew gem install cfn-nag
 ```
 
 # Pipeline

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ gem install cfn-nag
 
 ## Brew Install
 On MacOS or Linux (tested on ubuntu) install with brew
-```
+
+```bash
 brew tap stelligent/homebrew-tap
 brew install cfn-nag
 ```

--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@ For more background on the tool, please see:
 
 # Installation
 
-Presuming Ruby 2.5.x is installed, installation is just a matter of `
+## Gem Install 
+Presuming Ruby >= 2.5.x is installed, installation is just a matter of `
 
 ```bash
 gem install cfn-nag
+```
+
+## Brew Install
+On MacOS or Linux (tested on ubuntu) install with brew
+```
+brew tap stelligent/homebrew-tap
+brew install cfn-nag
 ```
 
 # Pipeline

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -2,5 +2,6 @@
 
 echo "Installing cfn_nag from local source"
 gem uninstall cfn-nag -x
+brew gem uninstall cfn-nag
 GEM_VERSION=0.0.01 gem build cfn-nag.gemspec
 gem install cfn-nag-0.0.01.gem --no-document


### PR DESCRIPTION
Closes #86 

Update Readme to include brew gem installation method.

@erickascic The brew tap solution would require homebrew-tap/Formula/cfn-nag.rb to be updated any time a dependency of cfn-nag.gemspec gets updated. We could make a script that reads cfn-nag.gemspec and then writes a new homebrew-tap/Formula/cfn-nag.rb but that means having to handle the `~>` and seems messy and prone to errors.  The `brew-gem` does not ensure ruby is installed, but that is easy enough to add to the install instructions:

```
brew install ruby brew-gem
brew gem install cfn-nag
```

This appears to be the simplest from a maintenance standpoint and it is two commands just like the tap version would be, so the complexity for users is basically the same.