### PR TITLE
#269 Add output-format option to cfn_nag_rules

### DIFF
--- a/bin/cfn_nag_rules
+++ b/bin/cfn_nag_rules
@@ -14,6 +14,10 @@ opts = Trollop.options do
   opt :profile_path, 'Path to a profile file', type: :io,
                                                required: false,
                                                default: nil
+  opt :output_format,
+      'Format of results: [csv, json, txt]',
+      type: :string,
+      default: 'txt'
 end
 
 profile_definition = nil
@@ -22,6 +26,7 @@ unless opts[:profile_path].nil?
 end
 
 rule_dumper = CfnNagRuleDumper.new(profile_definition: profile_definition,
-                                   rule_directory: opts[:rule_directory])
+                                   rule_directory: opts[:rule_directory],
+                                   output_format: opts[:output_format])
 
 rule_dumper.dump_rules

--- a/lib/cfn-nag/result_view/rules_view.rb
+++ b/lib/cfn-nag/result_view/rules_view.rb
@@ -26,7 +26,7 @@ class RulesView
   private
 
   def emit_txt(warnings, failings)
-    output_pattern = '%{id} %{message}'
+    output_pattern = '%<id>s %<message>s'
     puts 'WARNING VIOLATIONS:'
     emit_rules(warnings, output_pattern)
     puts
@@ -35,7 +35,7 @@ class RulesView
   end
 
   def emit_csv(warnings, failings)
-    output_pattern = '%{type},%{id},"%{message}"'
+    output_pattern = '%<type>s,%<id>s,"%<message>s"'
     puts 'Type,ID,Message'
     emit_rules(failings, output_pattern)
     emit_rules(warnings, output_pattern)
@@ -55,7 +55,7 @@ class RulesView
                  rules
                else
                  rules.select { |rule| profile.contains_rule?(rule.id) }
-                end
+               end
     selected.sort { |left, right| sort_id(left, right) }
   end
 
@@ -70,7 +70,7 @@ class RulesView
     rules.each do |rule|
       rule_array << rule.to_h
     end
-    puts rule_array.to_json
+    puts JSON.pretty_generate(rule_array)
   end
 
   def sort_id(left, right)

--- a/lib/cfn-nag/result_view/rules_view.rb
+++ b/lib/cfn-nag/result_view/rules_view.rb
@@ -7,11 +7,11 @@ class RulesView
   def emit(rule_registry, profile, output_format: 'txt')
     warnings = select_rules(rule_registry.warnings, profile)
     failings = select_rules(rule_registry.failings, profile)
+    rules = failings + warnings
     case output_format
     when 'csv'
-      emit_csv(warnings, failings)
+      emit_csv(rules)
     when 'json'
-      rules = failings + warnings
       puts rules_to_json(rules)
     when 'txt'
       emit_txt(warnings, failings)
@@ -34,11 +34,10 @@ class RulesView
     emit_rules(failings, output_pattern)
   end
 
-  def emit_csv(warnings, failings)
+  def emit_csv(rules)
     output_pattern = '%<type>s,%<id>s,"%<message>s"'
     puts 'Type,ID,Message'
-    emit_rules(failings, output_pattern)
-    emit_rules(warnings, output_pattern)
+    emit_rules(rules, output_pattern)
   end
 
   def emit_duplicates(duplicates)

--- a/lib/cfn-nag/rule_dumper.rb
+++ b/lib/cfn-nag/rule_dumper.rb
@@ -6,9 +6,11 @@ require_relative 'result_view/rules_view'
 
 class CfnNagRuleDumper
   def initialize(profile_definition: nil,
-                 rule_directory: nil)
+                 rule_directory: nil,
+                 output_format: nil)
     @rule_directory = rule_directory
     @profile_definition = profile_definition
+    @output_format = output_format
   end
 
   def dump_rules
@@ -21,6 +23,6 @@ class CfnNagRuleDumper
                              .load(profile_definition: @profile_definition)
     end
 
-    RulesView.new.emit(rule_registry, profile)
+    RulesView.new.emit(rule_registry, profile, output_format: @output_format)
   end
 end

--- a/spec/rule_dumper_spec.rb
+++ b/spec/rule_dumper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfn-nag/rule_dumper'
 
 describe CfnNagRuleDumper do
@@ -11,19 +13,70 @@ describe CfnNagRuleDumper do
     end
   end
 
-  context 'simple profile' do
+  context 'simple profile and txt output format' do
     before(:each) do
       @rule_dumper = CfnNagRuleDumper.new profile_definition: "F1\nF9\n",
-                                          rule_directory: nil
+                                          rule_directory: nil,
+                                          output_format: 'txt'
     end
 
-    it 'emits list of rules' do
+    it 'emits list of rules in text' do
       expected_output = <<OUTPUTSTRING
 WARNING VIOLATIONS:
 
 FAILING VIOLATIONS:
 F1 EBS volume should have server-side encryption enabled
 F9 S3 Bucket policy should not allow Allow+NotPrincipal
+OUTPUTSTRING
+
+      expect do
+        @rule_dumper.dump_rules
+      end.to output(expected_output).to_stdout
+    end
+  end
+
+  context 'simple profile and csv ouput format' do
+    before(:each) do
+      @rule_dumper = CfnNagRuleDumper.new profile_definition: "F1\nF9\n",
+                                          rule_directory: nil,
+                                          output_format: 'csv'
+    end
+
+    it 'emits list of rules in csv' do
+      expected_output = <<OUTPUTSTRING
+Type,ID,Message
+FAIL,F1,"EBS volume should have server-side encryption enabled"
+FAIL,F9,"S3 Bucket policy should not allow Allow+NotPrincipal"
+OUTPUTSTRING
+
+      expect do
+        @rule_dumper.dump_rules
+      end.to output(expected_output).to_stdout
+    end
+  end
+
+  context 'simple profile amd json format' do
+    before(:each) do
+      @rule_dumper = CfnNagRuleDumper.new profile_definition: "F1\nF9\n",
+                                          rule_directory: nil,
+                                          output_format: 'json'
+    end
+
+    it 'emits list of rules in json' do
+      expected_output = <<OUTPUTSTRING
+[
+  {
+    "id": "F1",
+    "type": "FAIL",
+    "message": "EBS volume should have server-side encryption enabled"
+  },
+  {
+    "id": "F9",
+    "type": "FAIL",
+    "message": "S3 Bucket policy should not allow Allow+NotPrincipal"
+  }
+]
+
 OUTPUTSTRING
 
       expect do


### PR DESCRIPTION
Adding csv and json options to cfn_nag_rules output.

This version without the `--output-format` option returns the same text output as previous version.  Tested this with and without `--profile-path` 

Custom rules accessed via `--rule-directory` do not appear to be showing up in output (before or after this change)

**Note**: If there are any duplicate rules, then the error message is listed after the formatted ouput. 

Examples
```
$ cfn_nag_rules --profile-path profile.list 
WARNING VIOLATIONS:
W1 Specifying credentials in the template itself is probably not the safest thing
W11 IAM role should not allow * resource on its permissions policy

FAILING VIOLATIONS:
F2 IAM role should not allow * action on its trust policy
F22 RDS instance should not be publicly accessible

twells@Todds-MBP:~/repos/cfn_nag (feature/269) 
$ cfn_nag_rules --profile-path profile.list --output-format json
[{"id":"F2","type":"FAIL","message":"IAM role should not allow * action on its trust policy"},{"id":"F22","type":"FAIL","message":"RDS instance should not be publicly accessible"},{"id":"W1","type":"WARN","message":"Specifying credentials in the template itself is probably not the safest thing"},{"id":"W11","type":"WARN","message":"IAM role should not allow * resource on its permissions policy"}]

twells@Todds-MBP:~/repos/cfn_nag (feature/269) 
$ cfn_nag_rules --profile-path profile.list --output-format csv
Type,ID,Message
FAIL,F2,"IAM role should not allow * action on its trust policy"
FAIL,F22,"RDS instance should not be publicly accessible"
WARN,W1,"Specifying credentials in the template itself is probably not the safest thing"
WARN,W11,"IAM role should not allow * resource on its permissions policy"

$ /Users/twells/.gem/bin/cfn_nag_rules -r /tmp/cfn_nag_rules/ -o csv
Type,ID,Message
FAIL,F1,"EBS volume should have server-side encryption enabled"
...
WARN,W37,"EBS Volume should specify a KmsKeyId value"
------------------
Rule ID conflict detected for W35.
New rule: S3 Bucket should have access logging configured
Registered rule: S3 Bucket should have access logging configured
```