### PR TITLE
#77 Convert publish.sh script to ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit_test:
     docker:
-      - image: circleci/ruby:2.5.5-browsers
+      - image: circleci/ruby:2.5.5-node-browsers
     steps:
       - checkout
       - run:
@@ -22,7 +22,7 @@ jobs:
           command: bundle exec ./bin/cfn_nag_rules
   end_to_end_test:
     docker:
-      - image: circleci/ruby:2.5.5-browsers
+      - image: circleci/ruby:2.5.5-node-browsers
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
           command: bash ./scripts/setup_and_run_end_to_end_tests.sh
   publish:
     docker:
-      - image: circleci/ruby:2.5.5-browsers
+      - image: circleci/ruby:2.5.5-node-browsers
     steps:
       - checkout
       - run:

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Validate commit message
+if ! grep -qE "^(Merge|#[0-9][0-9]* )" "$1";then
+    cat "$1"
+    echo "Your commit message must start with a Issue id (example: #23) or be a Merge commit"
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /Gemfile.lock
 /coverage
 /spec/aws_sample_templates/
+.vscode
 *.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+init:
+	git config core.hooksPath .githooks
+	gem install bundle
+	bundle install

--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('logging', '~> 2.2.2')
   s.add_runtime_dependency('netaddr', '~> 1.5.1')
   s.add_runtime_dependency('trollop', '~> 2.1.2')
+  s.add_runtime_dependency('docker-api', '~> 1.34.2')
 end

--- a/changelog-template.hbs
+++ b/changelog-template.hbs
@@ -1,0 +1,13 @@
+{{#each releases}}
+### [{{title}}]({{href}})
+> {{niceDate}}
+{{#if merges}}
+{{#each merges}}
+- {{message}} (PR #[{{id}}]({{href}}))
+{{/each}}
+{{/if}}
+{{#commit-list commits heading=''}}
+- {{subject}}
+{{/commit-list}}
+
+{{/each}}

--- a/lib/cfn-nag/util/git.rb
+++ b/lib/cfn-nag/util/git.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'git'
+
+def repo_current_info(_location)
+  git = open_repo(location)
+
+  current_tag = git.describe
+  current_version = current_tag.gsub(/v?([0-9.]+).*/, '\1')
+  major, minor, patch = current_version.split('.')
+
+  { 'tag' => current_tag,
+    'tagged_commit' => (current_tag.include?('-') ? 1 : 0),
+    'version' => current_version,
+    'major' => major,
+    'minor' => minor,
+    'patch' => patch }
+end
+
+private
+
+def open_repo(location)
+  git = Git.open(location)
+  git.config('user.name', 'build') if git.config('user.name').empty?
+  git.config('user.email', 'build@build.com') if git.config('user.email').empty?
+  git
+rescue StandardError => git_error
+  abort("Git error for #{location}: #{git_error}")
+end

--- a/lib/cfn-nag/util/git.rb
+++ b/lib/cfn-nag/util/git.rb
@@ -2,19 +2,27 @@
 
 require 'git'
 
-def repo_current_info(_location)
+def repo_current_info(location)
   git = open_repo(location)
 
   current_tag = git.describe
   current_version = current_tag.gsub(/v?([0-9.]+).*/, '\1')
   major, minor, patch = current_version.split('.')
+  new_version = (current_tag.include?('-') ? "#{major}.#{minor}.#{patch.to_i + 1}" : nil)
 
   { 'tag' => current_tag,
-    'tagged_commit' => (current_tag.include?('-') ? 1 : 0),
     'version' => current_version,
     'major' => major,
     'minor' => minor,
-    'patch' => patch }
+    'patch' => patch,
+    'new_version' => new_version }
+rescue Git::GitExecuteError
+  { 'tag' => nil,
+    'version' => nil,
+    'major' => nil,
+    'minor' => nil,
+    'patch' => nil,
+    'new_version' => '0.0.1' }
 end
 
 private
@@ -25,5 +33,9 @@ def open_repo(location)
   git.config('user.email', 'build@build.com') if git.config('user.email').empty?
   git
 rescue StandardError => git_error
-  abort("Git error for #{location}: #{git_error}")
+  raise "Git error for #{location}: #{git_error}"
 end
+
+# åputs open_repo('/tmp/dir1')
+# puts repo_current_info('/tmp/repo1')
+# puts repo_current_info('~/repos/cfn_nag')

--- a/lib/cfn-nag/util/git.rb
+++ b/lib/cfn-nag/util/git.rb
@@ -8,21 +8,28 @@ def repo_current_info(location)
   current_tag = git.describe
   current_version = current_tag.gsub(/v?([0-9.]+).*/, '\1')
   major, minor, patch = current_version.split('.')
-  new_version = (current_tag.include?('-') ? "#{major}.#{minor}.#{patch.to_i + 1}" : nil)
+  tagged_commit = !current_tag.include?('-')
+  next_version = "#{major}.#{minor}.#{patch.to_i + 1}"
 
   { 'tag' => current_tag,
     'version' => current_version,
-    'major' => major,
-    'minor' => minor,
-    'patch' => patch,
-    'new_version' => new_version }
+    'next_version' => next_version,
+    'tagged_commit' => tagged_commit }
 rescue Git::GitExecuteError
   { 'tag' => nil,
     'version' => nil,
-    'major' => nil,
-    'minor' => nil,
-    'patch' => nil,
-    'new_version' => '0.0.1' }
+    'next_version' => '0.0.1',
+    'tagged_commit' => false }
+end
+
+def tag_repo(repo_dir, tag_name)
+  git = open_repo(repo_dir)
+  git.add_tag(tag_name, message: tag_name)
+  begin
+    git.push
+  rescue StandardError => git_error
+    raise "Git error pushing tag: #{git_error} "
+  end
 end
 
 private

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cfn_nag",
+  "auto-changelog": {
+    "replaceText": {
+      "^#(\\d+)( -)?(.*)": "$3 (Issue #[$1](https://github.com/stelligent/cfn_nag/issues/$1))"
+    }
+  }
+}

--- a/scripts/publish.rb
+++ b/scripts/publish.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'git'
+require 'fileutils'
+require 'cfn-nag/util/git.rb'
+require 'docker'
+
+GEM_DIR = '~/.gem'
+REPO_DIR = '.'
+
+private
+
+def validate_env
+  ENV.fetch('rubygems_api_key')
+  ENV.fetch('docker_user')
+  ENV.fetch('docker_password')
+rescue StandardError => exception
+  abort("Error: #{exception}")
+end
+
+def build_gem
+  system('gem build cfn-nag.gemspec')
+  system('gem push cfn-nag-${gem_version}.gem')
+end
+
+def publish_docker_image(gem_version)
+  image = Docker::Image.build_from_dir('.')
+  image.tag('repo' => "#{ENV['docker_org']}/cfn_nag",
+            'tag' => gem_version,
+            'tag' => 'latest')
+  image.push
+  image.push(nil, tag: gem_version)
+  image.push(nil, tag: 'latest')
+end
+
+validate_env
+repo_info = repo_current_info(REPO_DIR)
+tag_repo(REPO_DIR, repo_info['next_version']) unless repo_info['tagged_commit']
+gem_version = (repo_info['tagged_commit'] ? repo_info['version'] : repo_info['next_version'])
+build_gem
+publish_docker_image(gem_version)

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -92,3 +92,9 @@ echo $docker_password | docker login -u $docker_user --password-stdin
 docker tag $docker_org/cfn_nag:${GEM_VERSION} $docker_org/cfn_nag:latest
 docker push $docker_org/cfn_nag:${GEM_VERSION}
 docker push $docker_org/cfn_nag:latest
+
+# Update Changelog
+node node_modules/auto-changelog/lib/index.js --template changelog-template.hbs
+git add CHANGELOG.md
+git commit -m "Update Changelog [skip ci]"
+git push

--- a/spec/util/git_spec.rb
+++ b/spec/util/git_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cfn-nag/util/git.rb'
+require 'git'
+
+describe 'open_repo', :rule do
+  context 'Location is a valid repo' do
+    it 'returns a repo object' do
+      Dir.mktmpdir do |dir|
+        Git.init(dir)
+        expect(open_repo(dir)).to(be_an(Git::Base))
+      end
+    end
+  end
+  context 'Location is not a valid repo' do
+    it 'returns error' do
+      Dir.mktmpdir do |dir|
+        expect(open_repo(dir).to(raise_error))
+      end
+    end
+  end
+end

--- a/spec/util/git_spec.rb
+++ b/spec/util/git_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 require 'cfn-nag/util/git.rb'
 require 'git'
 
-describe 'open_repo', :rule do
-  context 'Location is a valid repo' do
+describe 'git', :rule do
+  context 'open_repo when location is a valid repo' do
     it 'returns a repo object' do
       Dir.mktmpdir do |dir|
         Git.init(dir)
@@ -13,10 +13,51 @@ describe 'open_repo', :rule do
       end
     end
   end
-  context 'Location is not a valid repo' do
-    it 'returns error' do
+
+  context 'open_repo when location is not a valid repo' do
+    it 'raises error' do
       Dir.mktmpdir do |dir|
-        expect(open_repo(dir).to(raise_error))
+        expect { open_repo(dir) }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  context 'repo_current_info for a repo without tags' do
+    it 'returns new_version 0.0.1' do
+      Dir.mktmpdir do |dir|
+        Git.init(dir)
+        expect(repo_current_info(dir)).to include('tag' => nil, 'version' => nil, 'major' => nil, 'minor' => nil, 'patch' => nil, 'new_version' => '0.0.1')
+      end
+    end
+  end
+
+  context 'repo_current_info for a repo with tag on latest commit' do
+    it 'returns existing version' do
+      Dir.mktmpdir do |dir|
+        Git.init(dir)
+        git = open_repo(dir)
+        File.open("#{dir}/file1", 'w+') { |file| file.write('dummy data') }
+        git.add("#{dir}/file1")
+        git.commit('test commit')
+        git.add_tag('v1.0.1', message: 'v1.0.1')
+        expect(repo_current_info(dir)).to include('tag' => 'v1.0.1', 'version' => '1.0.1', 'major' => '1', 'minor' => '0', 'patch' => '1', 'new_version' => nil)
+      end
+    end
+  end
+
+  context 'repo_current_info for a repo with commits after last tag' do
+    it 'returns existing version' do
+      Dir.mktmpdir do |dir|
+        Git.init(dir)
+        git = open_repo(dir)
+        File.open("#{dir}/file1", 'w+') { |file| file.write('dummy data') }
+        git.add("#{dir}/file1")
+        git.commit('test commit')
+        git.add_tag('v1.0.1', message: 'v1.0.1')
+        File.open("#{dir}/file2", 'w+') { |file| file.write('dummy data') }
+        git.add("#{dir}/file2")
+        git.commit('test commit2')
+        expect(repo_current_info(dir)).to include('version' => '1.0.1', 'major' => '1', 'minor' => '0', 'patch' => '1', 'new_version' => '1.0.2')
       end
     end
   end

--- a/spec/util/git_spec.rb
+++ b/spec/util/git_spec.rb
@@ -26,13 +26,13 @@ describe 'git', :rule do
     it 'returns new_version 0.0.1' do
       Dir.mktmpdir do |dir|
         Git.init(dir)
-        expect(repo_current_info(dir)).to include('tag' => nil, 'version' => nil, 'major' => nil, 'minor' => nil, 'patch' => nil, 'new_version' => '0.0.1')
+        expect(repo_current_info(dir)).to include('tag' => nil, 'version' => nil, 'next_version' => '0.0.1')
       end
     end
   end
 
   context 'repo_current_info for a repo with tag on latest commit' do
-    it 'returns existing version' do
+    it 'returns tagged_commit true' do
       Dir.mktmpdir do |dir|
         Git.init(dir)
         git = open_repo(dir)
@@ -40,13 +40,13 @@ describe 'git', :rule do
         git.add("#{dir}/file1")
         git.commit('test commit')
         git.add_tag('v1.0.1', message: 'v1.0.1')
-        expect(repo_current_info(dir)).to include('tag' => 'v1.0.1', 'version' => '1.0.1', 'major' => '1', 'minor' => '0', 'patch' => '1', 'new_version' => nil)
+        expect(repo_current_info(dir)).to include('tag' => 'v1.0.1', 'version' => '1.0.1', 'next_version' => '1.0.2', 'tagged_commit' => true)
       end
     end
   end
 
   context 'repo_current_info for a repo with commits after last tag' do
-    it 'returns existing version' do
+    it 'returns tagged_commit false' do
       Dir.mktmpdir do |dir|
         Git.init(dir)
         git = open_repo(dir)
@@ -57,7 +57,21 @@ describe 'git', :rule do
         File.open("#{dir}/file2", 'w+') { |file| file.write('dummy data') }
         git.add("#{dir}/file2")
         git.commit('test commit2')
-        expect(repo_current_info(dir)).to include('version' => '1.0.1', 'major' => '1', 'minor' => '0', 'patch' => '1', 'new_version' => '1.0.2')
+        expect(repo_current_info(dir)).to include('version' => '1.0.1', 'next_version' => '1.0.2', 'tagged_commit' => false)
+      end
+    end
+  end
+
+  context 'tag_repo' do
+    it 'tags the repo' do
+      Dir.mktmpdir do |dir|
+        Git.init(dir)
+        git = open_repo(dir)
+        File.open("#{dir}/file1", 'w+') { |file| file.write('dummy data') }
+        git.add("#{dir}/file1")
+        git.commit('test commit')
+        tag_repo(dir, 'v1.1.1')
+        expect(git.tag('v1.1.1')).to be_an_instance_of(Git::Object::Tag)
       end
     end
   end


### PR DESCRIPTION
Replace godawful publish.sh with a readable Ruby version

**This PR needs testing**
The publish.rb has specs and passes those tests, but there is currently no environment for testing it in an end-to-end manner.  