### PR TITLE
Update netaddr to resolve CVE-2019-17383

### DIFF
--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('colorize', '0.8.1')
   s.add_runtime_dependency('jmespath', '~> 1.3.1')
   s.add_runtime_dependency('logging', '~> 2.2.2')
-  s.add_runtime_dependency('netaddr', '~> 1.5.1')
+  s.add_runtime_dependency('netaddr', '~> 2.0.4')
   s.add_runtime_dependency('trollop', '~> 2.1.2')
 end

--- a/lib/cfn-nag/ip_addr.rb
+++ b/lib/cfn-nag/ip_addr.rb
@@ -15,8 +15,7 @@ module IpAddr
 
     # only care about literals.  if a Hash/Ref not going to chase it down
     # given likely a Parameter with external val
-    (NetAddr::CIDRv6.create(normalized_cidr_ip6) ==
-     NetAddr::CIDRv6.create('::/0'))
+    NetAddr::IPv6Net.parse(normalized_cidr_ip6).cmp(NetAddr::IPv6Net.parse('::/0')).zero?
   end
 
   def ip4_cidr_range?(ingress)
@@ -29,7 +28,7 @@ module IpAddr
 
     # only care about literals.  if a Hash/Ref not going to chase it down
     # given likely a Parameter with external val
-    !NetAddr::CIDRv6.create(normalized_cidr_ip6).to_s.end_with?('/128')
+    !NetAddr::IPv6Net.parse(normalized_cidr_ip6).to_s.end_with?('/128')
   end
 
   ##


### PR DESCRIPTION
Update dependency netaddr to resolve https://nvd.nist.gov/vuln/detail/CVE-2019-17383