### PR TITLE
Adding violation rule for SQS Queue - KmsMasterKeyId property. Issue #315

### DIFF
--- a/lib/cfn-nag/custom_rules/SqsQueueKmsMasterKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SqsQueueKmsMasterKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class SqsQueueKmsMasterKeyIdRule < BaseRule
+  def rule_text
+    'SQS Queue should specify KmsMasterKeyId property'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W48'
+  end
+
+  def audit_impl(cfn_model)
+    violating_sqs_queues = cfn_model.resources_by_type('AWS::SQS::Queue').select do |sqs_queue|
+      sqs_queue.kmsMasterKeyId.nil?
+    end
+
+    violating_sqs_queues.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/SqsQueueKmsMasterKeyIdRule_spec.rb
+++ b/spec/custom_rules/SqsQueueKmsMasterKeyIdRule_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/SqsQueueKmsMasterKeyIdRule'
+
+describe SqsQueueKmsMasterKeyIdRule do
+  context 'sqs queue with no KmsMasterKeyId property defined.' do
+    it 'returns offending logical resource ids' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sqs/sqs_queue_kms_master_key_id_not_defined.yaml')
+
+      actual_logical_resource_ids = SqsQueueKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[SqsQueue2]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'sqs queue with KmsMasterKeyId property defined.' do
+    it 'an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sqs/sqs_queue_kms_master_key_id_defined.yaml')
+
+      actual_logical_resource_ids = SqsQueueKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'sqs queue with KmsMasterKeyId property defined and referencing parameter.' do
+    it 'an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sqs/sqs_queue_kms_master_key_id_defined_with_parameter.yaml')
+
+      actual_logical_resource_ids = SqsQueueKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_defined.yaml
+++ b/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_defined.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  SqsQueue1:
+    Type: AWS::SQS::Queue
+    Properties: 
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      QueueName: sqsqueue1
+
+  SqsQueue2:
+    Type: AWS::SQS::Queue
+    Properties: 
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      QueueName: sqsqueue2

--- a/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_defined_with_parameter.yaml
+++ b/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_defined_with_parameter.yaml
@@ -1,0 +1,18 @@
+---
+Parameters:
+  KmsMasterKeyId:
+    Type: String
+    Default: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+
+Resources:
+  SqsQueue1:
+    Type: AWS::SQS::Queue
+    Properties: 
+      KmsMasterKeyId: !Ref KmsMasterKeyId
+      QueueName: sqsqueue1
+
+  SqsQueue2:
+    Type: AWS::SQS::Queue
+    Properties: 
+      KmsMasterKeyId: !Ref KmsMasterKeyId
+      QueueName: sqsqueue2

--- a/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_not_defined.yaml
+++ b/spec/test_templates/yaml/sqs/sqs_queue_kms_master_key_id_not_defined.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  SqsQueue1:
+    Type: AWS::SQS::Queue
+    Properties: 
+      QueueName: sqsqueue1
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+
+  SqsQueue2:
+    Type: AWS::SQS::Queue
+    Properties: 
+      QueueName: sqsqueue2


### PR DESCRIPTION
Checks to see if the `KmsMasterKeyId` property is defined for a SQS Queue resource and flags a warning violation if it is not. For Issue #315