### PR TITLE
Feature/issue 314 sns topic kmsmasterkeyid - Issue #314

### DIFF
--- a/lib/cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 
 class SnsTopicKmsMasterKeyIdRule < BaseRule
   def rule_text
-    'SNS Topic policy should specify KmsMasterKeyId property'
+    'SNS Topic should specify KmsMasterKeyId property'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class SnsTopicKmsMasterKeyIdRule < BaseRule
+  def rule_text
+    'SNS Topic policy should specify KmsMasterKeyId property'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W47'
+  end
+
+  def audit_impl(cfn_model)
+    violating_sns_topics = cfn_model.resources_by_type('AWS::SNS::Topic').select do |topic|
+      topic.kmsMasterKeyId.nil?
+    end
+
+    violating_sns_topics.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/SnsTopicKmsMasterKeyIdRule_spec.rb
+++ b/spec/custom_rules/SnsTopicKmsMasterKeyIdRule_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule'
+
+describe SnsTopicKmsMasterKeyIdRule do
+  context 'sns topic policy with no KmsMasterKeyId property defined.' do
+    it 'returns offending logical resource ids' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_not_defined.yaml')
+
+      actual_logical_resource_ids = SnsTopicKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[SnsTopic1]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'sns topic policy with KmsMasterKeyId property defined.' do
+    it 'an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_defined.yaml')
+
+      actual_logical_resource_ids = SnsTopicKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'sns topic policy with KmsMasterKeyId property defined and referencing parameter.' do
+    it 'an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_defined_with_parameter.yaml')
+
+      actual_logical_resource_ids = SnsTopicKmsMasterKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/custom_rules/SnsTopicKmsMasterKeyIdRule_spec.rb
+++ b/spec/custom_rules/SnsTopicKmsMasterKeyIdRule_spec.rb
@@ -3,7 +3,7 @@ require 'cfn-model'
 require 'cfn-nag/custom_rules/SnsTopicKmsMasterKeyIdRule'
 
 describe SnsTopicKmsMasterKeyIdRule do
-  context 'sns topic policy with no KmsMasterKeyId property defined.' do
+  context 'sns topic with no KmsMasterKeyId property defined.' do
     it 'returns offending logical resource ids' do
       cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_not_defined.yaml')
 
@@ -14,7 +14,7 @@ describe SnsTopicKmsMasterKeyIdRule do
     end
   end
 
-  context 'sns topic policy with KmsMasterKeyId property defined.' do
+  context 'sns topic with KmsMasterKeyId property defined.' do
     it 'an empty list' do
       cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_defined.yaml')
 
@@ -25,7 +25,7 @@ describe SnsTopicKmsMasterKeyIdRule do
     end
   end
 
-  context 'sns topic policy with KmsMasterKeyId property defined and referencing parameter.' do
+  context 'sns topic with KmsMasterKeyId property defined and referencing parameter.' do
     it 'an empty list' do
       cfn_model = CfnParser.new.parse read_test_template('yaml/sns/sns_topic_kms_master_key_id_defined_with_parameter.yaml')
 

--- a/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_defined.yaml
+++ b/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_defined.yaml
@@ -1,0 +1,14 @@
+Resources:
+  SnsTopic1:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic1
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      TopicName: snstopic1
+
+  SnsTopic2:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic2
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      TopicName: snstopic2

--- a/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_defined_with_parameter.yaml
+++ b/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_defined_with_parameter.yaml
@@ -1,0 +1,19 @@
+---
+Parameters:
+  KmsMasterKeyId:
+    Type: String
+    Default: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+Resources:
+  SnsTopic1:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic1
+      KmsMasterKeyId: !Ref KmsMasterKeyId
+      TopicName: snstopic1
+
+  SnsTopic2:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic2
+      KmsMasterKeyId: !Ref KmsMasterKeyId
+      TopicName: snstopic2

--- a/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_not_defined.yaml
+++ b/spec/test_templates/yaml/sns/sns_topic_kms_master_key_id_not_defined.yaml
@@ -1,0 +1,13 @@
+Resources:
+  SnsTopic1:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic1
+      TopicName: snstopic1
+
+  SnsTopic2:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: snstopic2
+      KmsMasterKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+      TopicName: snstopic2


### PR DESCRIPTION
Checks to see if the `KmsMasterKeyId` property is defined for a SNS Topic resource and flags a warning violation if it is not. For Issue #314 