### PR TITLE
Feature/add secure rule for alexa ask skill authentication configuration

### DIFF
--- a/lib/cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationClientSecretRule.rb
+++ b/lib/cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationClientSecretRule.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class AlexaASKSkillAuthenticationConfigurationClientSecretRule < BaseRule
+  def rule_text
+    'Alexa ASK Skill AuthenticationConfiguration ClientSecret must not be ' \
+    'a plaintext string or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F74'
+  end
+
+  def audit_impl(cfn_model)
+    ask_skills = cfn_model.resources_by_type('Alexa::ASK::Skill')
+    violating_skills = ask_skills.select do |skill|
+      client_secret = skill.authenticationConfiguration['ClientSecret']
+      if client_secret.nil?
+        false
+      else
+        insecure_parameter?(cfn_model, client_secret) ||
+          insecure_string_or_dynamic_reference?(cfn_model, client_secret)
+      end
+    end
+
+    violating_skills.map(&:logical_resource_id)
+  end
+end

--- a/lib/cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.rb
+++ b/lib/cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class AlexaASKSkillAuthenticationConfigurationRefreshTokenRule < BaseRule
+  def rule_text
+    'Alexa ASK Skill AuthenticationConfiguration RefreshToken must not be ' \
+    'a plaintext string or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F75'
+  end
+
+  def audit_impl(cfn_model)
+    ask_skills = cfn_model.resources_by_type('Alexa::ASK::Skill')
+    violating_skills = ask_skills.select do |skill|
+      refresh_token = skill.authenticationConfiguration['RefreshToken']
+      if refresh_token.nil?
+        false
+      else
+        insecure_parameter?(cfn_model, refresh_token) ||
+          insecure_string_or_dynamic_reference?(cfn_model, refresh_token)
+      end
+    end
+
+    violating_skills.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/AlexaASKSkillAuthenticationConfigurationClientSecretRule_spec.rb
+++ b/spec/custom_rules/AlexaASKSkillAuthenticationConfigurationClientSecretRule_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationClientSecretRule'
+
+describe AlexaASKSkillAuthenticationConfigurationClientSecretRule, :rule do
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret not set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret parameter with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret parameter with NoEcho and Default value' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho_and_default_value.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret parameter as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_parameter_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_from_secrets_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_from_secure_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration ClientSecret from Systems Manager' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_client_secret_from_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationClientSecretRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/custom_rules/AlexaASKSkillAuthenticationConfigurationRefreshTokenRule_spec.rb
+++ b/spec/custom_rules/AlexaASKSkillAuthenticationConfigurationRefreshTokenRule_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/AlexaASKSkillAuthenticationConfigurationRefreshTokenRule'
+
+describe AlexaASKSkillAuthenticationConfigurationRefreshTokenRule, :rule do
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken not set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken parameter with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken parameter with NoEcho and Default value' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho_and_default_value.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken parameter as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_parameter_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_from_secrets_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_from_secure_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Alexa ASK Skill AuthenticationConfiguration RefreshToken from Systems Manager' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/alexa_ask_skill/' \
+        'alexa_ask_skill_authentication_configuration_refresh_token_from_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        AlexaASKSkillAuthenticationConfigurationRefreshTokenRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[AlexaASKSkill]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: b@dP@$sW0rD
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_secrets_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: '{{resolve:secretsmanager:/alexa/ask/skill/authenticationconfiguration_clientsecret:SecretString:password}}'
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_secure_systems_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_from_systems_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: '{{resolve:ssm:UnsecureSecretString:1}}'
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_not_set.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_not_set.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,19 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho.yaml
@@ -1,0 +1,20 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_client_secret_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,21 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: b@dP@$sW0rD
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_secrets_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: '{{resolve:secretsmanager:/alexa/ask/skill/authenticationconfiguration_refreshtoken:SecretString:password}}'
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_secure_systems_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_from_systems_manager.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: '{{resolve:ssm:UnsecureSecretString:1}}'
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_not_set.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_not_set.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,19 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho.yaml
@@ -1,0 +1,20 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar

--- a/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/alexa_ask_skill/alexa_ask_skill_authentication_configuration_refresh_token_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,21 @@
+---
+Parameters:
+  AlexaASKSkillAuthenticationConfigurationClientSecret:
+    Type: String
+    NoEcho: True
+  AlexaASKSkillAuthenticationConfigurationRefreshToken:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  AlexaASKSkill:
+    Type: Alexa::ASK::Skill
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      AuthenticationConfiguration:
+        ClientId: amzn1.application-oa2-client.foobar
+        ClientSecret: !Ref AlexaASKSkillAuthenticationConfigurationClientSecret
+        RefreshToken: !Ref AlexaASKSkillAuthenticationConfigurationRefreshToken
+      VendorId: foobar


### PR DESCRIPTION
Closes #322 

Creating two new rules for `Alexa::ASK::Skill.AuthenticationConfiguration`
- ClientSecret
- RefreshToken

These rules are using the `BaseRule` class. New specs are created to test familiar template scenarios.