### PR TITLE
Feature/253 amplify password rules

### DIFF
--- a/lib/cfn-nag/custom_rules/AmplifyAppAccessTokenRule.rb
+++ b/lib/cfn-nag/custom_rules/AmplifyAppAccessTokenRule.rb
@@ -14,7 +14,7 @@ class AmplifyAppAccessTokenRule < PasswordBaseRule
   end
 
   def rule_id
-    'F39'
+    'F41'
   end
 
   def resource_type

--- a/lib/cfn-nag/custom_rules/AmplifyAppAccessTokenRule.rb
+++ b/lib/cfn-nag/custom_rules/AmplifyAppAccessTokenRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class AmplifyAppAccessTokenRule < PasswordBaseRule
+  def rule_text
+    'Amplify App AccessToken must not be a plaintext string ' \
+    'or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F39'
+  end
+
+  def resource_type
+    'AWS::Amplify::App'
+  end
+
+  def password_property
+    :accessToken
+  end
+end

--- a/lib/cfn-nag/custom_rules/AmplifyAppOauthTokenRule.rb
+++ b/lib/cfn-nag/custom_rules/AmplifyAppOauthTokenRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class AmplifyAppOauthTokenRule < PasswordBaseRule
+  def rule_text
+    'Amplify App OauthToken must not be a plaintext string ' \
+    'or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F58'
+  end
+
+  def resource_type
+    'AWS::Amplify::App'
+  end
+
+  def password_property
+    :oauthToken
+  end
+end

--- a/lib/cfn-nag/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class AmplifyBranchBasicAuthConfigPasswordRule < PasswordBaseRule
+  def rule_text
+    'Amplify Branch BasicAuthConfig Password must not be a plaintext ' \
+    'string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F60'
+  end
+
+  def resource_type
+    'AWS::Amplify::Branch'
+  end
+
+  def password_property
+    :basicAuthConfig
+  end
+
+  def sub_property_name
+    'Password'
+  end
+end

--- a/lib/cfn-nag/custom_rules/IamPolicyPassRoleWildcardResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyPassRoleWildcardResourceRule.rb
@@ -13,7 +13,7 @@ class IamPolicyPassRoleWildcardResourceRule < PassRoleBaseRule
   end
 
   def rule_id
-    'F41'
+    'F39'
   end
 
   def policy_type

--- a/lib/cfn-nag/custom_rules/IamPolicyPassRoleWildcardResourceRule.rb
+++ b/lib/cfn-nag/custom_rules/IamPolicyPassRoleWildcardResourceRule.rb
@@ -13,7 +13,7 @@ class IamPolicyPassRoleWildcardResourceRule < PassRoleBaseRule
   end
 
   def rule_id
-    'F39'
+    'F41'
   end
 
   def policy_type

--- a/spec/custom_rules/AmplifyAppAccessTokenRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppAccessTokenRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::Amplify::App'
+password_property = 'AccessToken'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/AmplifyAppOauthTokenRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppOauthTokenRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::Amplify::App'
+password_property = 'OauthToken'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule_spec.rb
+++ b/spec/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::Amplify::Branch'
+password_property = 'BasicAuthConfig'
+sub_property_name = 'Password'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: b@d0@u7H70K3n
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_secrets_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: '{{resolve:secretsmanager:/amplify/app/accesstoken:SecretString:password}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_secure_systems_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_from_systems_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: '{{resolve:ssm:UnsecureSecretString:1}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_not_set.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_not_set.yaml
@@ -1,0 +1,6 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,10 @@
+---
+Parameters:
+  AmplifyAppAccessToken:
+    Type: String
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: !Ref AmplifyAppAccessToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_with_noecho.yaml
@@ -1,0 +1,11 @@
+---
+Parameters:
+  AmplifyAppAccessToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: !Ref AmplifyAppAccessToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_access_token_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,12 @@
+---
+Parameters:
+  AmplifyAppAccessToken:
+    Type: String
+    NoEcho: True
+    Default: b@d0@u7H70K3n
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      AccessToken: !Ref AmplifyAppAccessToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: b@d0@u7H70K3n
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_secrets_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: '{{resolve:secretsmanager:/amplify/app/oauthtoken:SecretString:password}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_secure_systems_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_from_systems_manager.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: '{{resolve:ssm:UnsecureSecretString:1}}'
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_not_set.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_not_set.yaml
@@ -1,0 +1,6 @@
+---
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,10 @@
+---
+Parameters:
+  AmplifyAppOauthToken:
+    Type: String
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: !Ref AmplifyAppOauthToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_with_noecho.yaml
@@ -1,0 +1,11 @@
+---
+Parameters:
+  AmplifyAppOauthToken:
+    Type: String
+    NoEcho: True
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: !Ref AmplifyAppOauthToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/amplify_app/amplify_app_oauth_token_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,12 @@
+---
+Parameters:
+  AmplifyAppOauthToken:
+    Type: String
+    NoEcho: True
+    Default: b@d0@u7H70K3n
+Resources:
+  AmplifyApp:
+    Type: AWS::Amplify::App
+    Properties:
+      OauthToken: !Ref AmplifyAppOauthToken
+      Name: foobar

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: b@dP@$sW0rD
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_secrets_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: '{{resolve:secretsmanager:/amplify/branch/basicauthconfig_password:SecretString:password}}'
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_secure_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_from_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_not_set.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_not_set.yaml
@@ -1,0 +1,9 @@
+---
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Parameters:
+  AmplifyBranchBasicAuthConfigPassword:
+    Type: String
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: !Ref AmplifyBranchBasicAuthConfigPassword
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_with_noecho.yaml
@@ -1,0 +1,14 @@
+---
+Parameters:
+  AmplifyBranchBasicAuthConfigPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: !Ref AmplifyBranchBasicAuthConfigPassword
+        Username: admin

--- a/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/amplify_branch/amplify_branch_basic_auth_config_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  AmplifyBranchBasicAuthConfigPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  AmplifyBranch:
+    Type: AWS::Amplify::Branch
+    Properties:
+      AppId: foo
+      BranchName: bar
+      BasicAuthConfig:
+        Password: !Ref AmplifyBranchBasicAuthConfigPassword
+        Username: admin


### PR DESCRIPTION
Partial for #253 

Creates rules for the following resource properties:
* AWS::Amplify::App AccessToken
* AWS::Amplify::App OauthToken
* AWS::Amplify::Branch.BasicAuthConfig Password