### PR TITLE
#253 adding AccountPassword rule for AppStream DirectoryConfig ServiceAccountCredentials

### DIFF
--- a/lib/cfn-nag/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule < PasswordBaseRule
+  def rule_text
+    'AppStream DirectoryConfig ServiceAccountCredentials AccountPassword ' \
+    'must not be a plaintext string or a Ref to a NoEcho Parameter ' \
+    'with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F53'
+  end
+
+  def resource_type
+    'AWS::AppStream::DirectoryConfig'
+  end
+
+  def password_property
+    :serviceAccountCredentials
+  end
+
+  def sub_property_name
+    'AccountPassword'
+  end
+end

--- a/spec/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule_spec.rb
+++ b/spec/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::AppStream::DirectoryConfig'
+password_property = 'ServiceAccountCredentials'
+sub_property_name = 'AccountPassword'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: b@dP@$sW0rD
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_secrets_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: '{{resolve:secretsmanager:/appstream/directoryconfig/serviceaccountcredentials_accountpassword:SecretString:password}}'
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_secure_systems_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_from_systems_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_not_set.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_not_set.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword:
+    Type: String
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: !Ref AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_with_noecho.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: !Ref AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword
+      DirectoryName: foobar.example.com

--- a/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/appstream_directoryconfig/appstream_directoryconfig_service_account_credentials_account_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,18 @@
+---
+Parameters:
+  AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  AppStreamDirectoryConfig:
+    Type: AWS::AppStream::DirectoryConfig
+    Properties:
+      OrganizationalUnitDistinguishedNames:
+        - foo
+        - bar
+        - baz
+      ServiceAccountCredentials:
+        AccountName: admin
+        AccountPassword: !Ref AppStreamDirectoryConfigServiceAccountCredentialsAccountPassword
+      DirectoryName: foobar.example.com


### PR DESCRIPTION
Partial for #253 

Creates rule for the following resource properties:
* AWS::AppStream::DirectoryConfig.ServiceAccountCredentials AccountPassword