### PR TITLE
#335 Adding warning if a KMS key allows wildcarded principals in its policy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cfn-nag (0.0.0)
-      cfn-model (= 0.4.11)
+      cfn-model (= 0.4.12)
       jmespath (~> 1.3.1)
       logging (~> 2.2.2)
       netaddr (~> 2.0.4)
@@ -12,7 +12,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    cfn-model (0.4.11)
+    cfn-model (0.4.12)
       kwalify (= 0.7.2)
       psych (~> 3)
     diff-lcs (1.3)

--- a/cfn-nag.gemspec
+++ b/cfn-nag.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   # versus what we used to run tests in cfn-nag before publishing cfn-nag
   # they are coupled and we are doing a good bit of experimenting in cfn-model
   # i might consider collapsing them again....
-  s.add_runtime_dependency('cfn-model', '0.4.11')
+  s.add_runtime_dependency('cfn-model', '0.4.12')
   s.add_runtime_dependency('jmespath', '~> 1.3.1')
   s.add_runtime_dependency('logging', '~> 2.2.2')
   s.add_runtime_dependency('netaddr', '~> 2.0.4')

--- a/lib/cfn-nag/custom_rules/KMSKeyWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/KMSKeyWildcardPrincipalRule.rb
@@ -9,11 +9,11 @@ class KMSKeyWildcardPrincipalRule < BaseRule
   end
 
   def rule_type
-    Violation::WARNING
+    Violation::FAILING_VIOLATION
   end
 
   def rule_id
-    'W55'
+    'F76'
   end
 
   def audit_impl(cfn_model)
@@ -22,7 +22,7 @@ class KMSKeyWildcardPrincipalRule < BaseRule
       # Select all key policy 'Statement' objects to audit
       violating_statements = key.keyPolicy['Statement'].select do |statement|
         # Add statement as violating if allowing wildcard principal
-        statement['Principal'] == '*' && statement['Effect'] == 'Allow'
+        (statement['Principal'] == '*' || statement['Principal']['AWS'] == '*') && statement['Effect'] == 'Allow'
       end
 
       !violating_statements.empty?

--- a/lib/cfn-nag/custom_rules/KMSKeyWildcardPrincipalRule.rb
+++ b/lib/cfn-nag/custom_rules/KMSKeyWildcardPrincipalRule.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class KMSKeyWildcardPrincipalRule < BaseRule
+  def rule_text
+    'KMS key should not allow * principal'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W55'
+  end
+
+  def audit_impl(cfn_model)
+    # Select all AWS::KMS::Key resources to audit
+    violating_keys = cfn_model.resources_by_type('AWS::KMS::Key').select do |key|
+      # Select all key policy 'Statement' objects to audit
+      violating_statements = key.keyPolicy['Statement'].select do |statement|
+        # Add statement as violating if allowing wildcard principal
+        statement['Principal'] == '*' && statement['Effect'] == 'Allow'
+      end
+
+      !violating_statements.empty?
+    end
+
+    violating_keys.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
@@ -28,5 +28,13 @@ describe KMSKeyWildcardPrincipalRule do
         expect(actual_logical_resource_ids).to eq ['myKeyAwsWildcardPrincipal']
       end
     end
+    context 'when a principal\'s AWS key is an array and contains a wildcard' do
+      it 'returns an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_aws_array_wildcard_principal.json')
+        actual_logical_resource_ids = KMSKeyWildcardPrincipalRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq ['myKeyAwsArrayWildcardPrincipal']
+      end
+    end
   end
 end

--- a/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
@@ -20,5 +20,13 @@ describe KMSKeyWildcardPrincipalRule do
         expect(actual_logical_resource_ids).to eq ['myKeyWildcardPrincipal']
       end
     end
+    context 'when a principal\'s AWS key is set to a wildcard' do
+      it 'returns an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_aws_wildcard_principal.json')
+        actual_logical_resource_ids = KMSKeyWildcardPrincipalRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq ['myKeyAwsWildcardPrincipal']
+      end
+    end
   end
 end

--- a/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
+++ b/spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'cfn-nag/custom_rules/KMSKeyWildcardPrincipalRule'
+require 'cfn-model'
+
+describe KMSKeyWildcardPrincipalRule do
+  describe 'AWS::KMS::Key' do
+    context 'when a principal is not set to a wildcard' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_without_wildcard_principal.json')
+        actual_logical_resource_ids = KMSKeyWildcardPrincipalRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+    context 'when a principal is set to a wildcard' do
+      it 'returns an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/kms/kms_key_with_wildcard_principal.json')
+        actual_logical_resource_ids = KMSKeyWildcardPrincipalRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq ['myKeyWildcardPrincipal']
+      end
+    end
+  end
+end

--- a/spec/test_templates/json/kms/kms_key_with_aws_array_wildcard_principal.json
+++ b/spec/test_templates/json/kms/kms_key_with_aws_array_wildcard_principal.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "myKeyAwsArrayWildcardPrincipal" : {
+      "Type" : "AWS::KMS::Key",
+      "Properties" : {
+        "Description" : "An example CMK",
+				"EnableKeyRotation": "true",
+        "KeyPolicy" : {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::111122223333:root"},
+              "Action": "kms:*",
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": {"AWS": ["arn:aws:iam::111122223333:root", "*"]},
+              "Action": [
+                "kms:Create*",
+                "kms:CancelKeyDeletion"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow use of the key",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::123456789012:user/Alice"},
+              "Action": [
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/kms/kms_key_with_aws_wildcard_principal.json
+++ b/spec/test_templates/json/kms/kms_key_with_aws_wildcard_principal.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "myKeyWildcardPrincipal" : {
+    "myKeyAwsWildcardPrincipal" : {
       "Type" : "AWS::KMS::Key",
       "Properties" : {
         "Description" : "An example CMK",
@@ -19,7 +19,7 @@
             {
               "Sid": "Allow administration of the key",
               "Effect": "Allow",
-              "Principal": { "CanonicalUser": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be" },
+              "Principal": {"AWS": "*"},
               "Action": [
                 "kms:Create*",
                 "kms:CancelKeyDeletion"
@@ -29,7 +29,7 @@
             {
               "Sid": "Allow use of the key",
               "Effect": "Allow",
-              "Principal": "*",
+              "Principal": {"AWS": "arn:aws:iam::123456789012:user/Alice"},
               "Action": [
                 "kms:GenerateDataKey",
                 "kms:GenerateDataKeyWithoutPlaintext"

--- a/spec/test_templates/json/kms/kms_key_with_wildcard_principal.json
+++ b/spec/test_templates/json/kms/kms_key_with_wildcard_principal.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "myKeyWildcardPrincipal" : {
+      "Type" : "AWS::KMS::Key",
+      "Properties" : {
+        "Description" : "An example CMK",
+				"EnableKeyRotation": "true",
+        "KeyPolicy" : {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::111122223333:root"},
+              "Action": "kms:*",
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": [
+                "kms:Create*",
+                "kms:CancelKeyDeletion"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow use of the key",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": [
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/kms/kms_key_without_wildcard_principal.json
+++ b/spec/test_templates/json/kms/kms_key_without_wildcard_principal.json
@@ -1,0 +1,44 @@
+{
+  "Resources": {
+    "myKeyNoWildcardPrincipal" : {
+      "Type" : "AWS::KMS::Key",
+      "Properties" : {
+        "Description" : "An example CMK",
+				"EnableKeyRotation": "true",
+        "KeyPolicy" : {
+          "Version": "2012-10-17",
+          "Id": "key-default-1",
+          "Statement": [
+            {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {"AWS": "arn:aws:iam::111122223333:root"},
+              "Action": "kms:*",
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow administration of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+              "Action": [
+                "kms:Create*",
+                "kms:CancelKeyDeletion"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "Allow use of the key",
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::123456789012:user/Bob" },
+              "Action": [
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/test_templates/yaml/kms/kms_key_with_aws_array_wildcard_principal.yml
+++ b/spec/test_templates/yaml/kms/kms_key_with_aws_array_wildcard_principal.yml
@@ -1,0 +1,35 @@
+---
+Resources:
+  myKeyAwsArrayWildcardPrincipal:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: An example CMK
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::111122223333:root
+            Action: kms:*
+            Resource: '*'
+          - Sid: Allow administration of the key
+            Effect: Allow
+            Principal:
+              AWS:
+                - arn:aws:iam::111122223333:root
+                - '*'
+            Action:
+              - kms:Create*
+              - kms:CancelKeyDeletion
+            Resource: '*'
+          - Sid: Allow use of the key
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:user/Alice
+            Action:
+              - kms:GenerateDataKey
+              - kms:GenerateDataKeyWithoutPlaintext
+            Resource: '*'

--- a/spec/test_templates/yaml/kms/kms_key_with_aws_wildcard_principal.yml
+++ b/spec/test_templates/yaml/kms/kms_key_with_aws_wildcard_principal.yml
@@ -1,6 +1,6 @@
 ---
 Resources:
-  myKeyWildcardPrincipal:
+  myKeyAwsWildcardPrincipal:
     Type: AWS::KMS::Key
     Properties:
       Description: An example CMK
@@ -18,14 +18,15 @@ Resources:
           - Sid: Allow administration of the key
             Effect: Allow
             Principal:
-              CanonicalUser: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+              AWS: '*'
             Action:
               - kms:Create*
               - kms:CancelKeyDeletion
             Resource: '*'
           - Sid: Allow use of the key
             Effect: Allow
-            Principal: '*'
+            Principal:
+              AWS: arn:aws:iam::123456789012:user/Alice
             Action:
               - kms:GenerateDataKey
               - kms:GenerateDataKeyWithoutPlaintext

--- a/spec/test_templates/yaml/kms/kms_key_with_wildcard_principal.yml
+++ b/spec/test_templates/yaml/kms/kms_key_with_wildcard_principal.yml
@@ -1,0 +1,32 @@
+---
+Resources:
+  myKeyWildcardPrincipal:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: An example CMK
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::111122223333:root
+            Action: kms:*
+            Resource: '*'
+          - Sid: Allow administration of the key
+            Effect: Allow
+            Principal: '*'
+            Action:
+              - kms:Create*
+              - kms:CancelKeyDeletion
+            Resource: '*'
+          - Sid: Allow use of the key
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:user/Alice
+            Action:
+              - kms:GenerateDataKey
+              - kms:GenerateDataKeyWithoutPlaintext
+            Resource: '*'

--- a/spec/test_templates/yaml/kms/kms_key_without_wildcard_principal.yml
+++ b/spec/test_templates/yaml/kms/kms_key_without_wildcard_principal.yml
@@ -1,0 +1,33 @@
+---
+Resources:
+  myKeyNoWildcardPrincipal:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: An example CMK
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-default-1
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::111122223333:root
+            Action: kms:*
+            Resource: '*'
+          - Sid: Allow administration of the key
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:user/Alice
+            Action:
+              - kms:Create*
+              - kms:CancelKeyDeletion
+            Resource: '*'
+          - Sid: Allow use of the key
+            Effect: Allow
+            Principal:
+              AWS: arn:aws:iam::123456789012:user/Bob
+            Action:
+              - kms:GenerateDataKey
+              - kms:GenerateDataKeyWithoutPlaintext
+            Resource: '*'


### PR DESCRIPTION
#335 

### Depends On
[stelligent/cfn-model PR #58](https://github.com/stelligent/cfn-model/pull/58)
Once the above PR is merged in cfn-model and a new gem artifact created, this PR will be able to execute.

### Description
Adding a failure to catch KMS key policy principals with wildcard values.

### Testing
Rspec test suite includes both positive and negative test cases from JSON templates, which pass while covering all relevant logic in the rule.  Added YAML templates for integration testing as well.

#### Example rspec Output
```
$ bundle exec rspec spec/custom_rules/KMSKeyWildcardPrincipalRule_spec.rb
Run options: exclude {:end_to_end=>true}
....

Finished in 0.01764 seconds (files took 0.34528 seconds to load)
4 examples, 0 failures

Coverage report generated for RSpec to cfn_nag/coverage. 33 / 66 LOC (50.0%) covered.
$
```

#### Example Integration Test Output
```
$  bundle exec cfn_nag --rule-directory lib spec/test_templates/yaml/kms/kms_key_without_wildcard_principal.yml
------------------------------------------------------------
spec/test_templates/yaml/kms/kms_key_without_wildcard_principal.yml
------------------------------------------------------------
Failures count: 0
Warnings count: 0
$
```

```
$ bundle exec cfn_nag --rule-directory lib spec/test_templates/yaml/kms/kms_key_with_aws_wildcard_principal.yml
------------------------------------------------------------
spec/test_templates/yaml/kms/kms_key_with_aws_wildcard_principal.yml
------------------------------------------------------------------------------------------------------------------------
| FAIL F76
|
| Resources: ["myKeyAwsWildcardPrincipal"]
| Line Numbers: [4]
|
| KMS key should not allow * principal (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)

Failures count: 1
Warnings count: 0
$
```

```
$ bundle exec cfn_nag --rule-directory lib spec/test_templates/yaml/kms/kms_key_with_wildcard_principal.yml
------------------------------------------------------------
spec/test_templates/yaml/kms/kms_key_with_wildcard_principal.yml
------------------------------------------------------------------------------------------------------------------------
| FAIL F76
|
| Resources: ["myKeyWildcardPrincipal"]
| Line Numbers: [4]
|
| KMS key should not allow * principal (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)

Failures count: 1
Warnings count: 0
$
```

```
$ bundle exec cfn_nag --rule-directory lib spec/test_templates/yaml/kms/kms_key_with_aws_array_wildcard_principal.yml
------------------------------------------------------------
spec/test_templates/yaml/kms/kms_key_with_aws_array_wildcard_principal.yml
------------------------------------------------------------------------------------------------------------------------
| FAIL F76
|
| Resources: ["myKeyAwsArrayWildcardPrincipal"]
| Line Numbers: [4]
|
| KMS key should not allow * principal (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)

Failures count: 1
Warnings count: 0
$
```