### PR TITLE
Feature/253 aws opsworks password rules

### DIFF
--- a/lib/cfn-nag/custom_rules/OpsWorksAppAppSourcePasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/OpsWorksAppAppSourcePasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class OpsWorksAppAppSourcePasswordRule < PasswordBaseRule
+  def rule_text
+    'OpsWorks App AppSource Password must not be a plaintext ' \
+    'string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F67'
+  end
+
+  def resource_type
+    'AWS::OpsWorks::App'
+  end
+
+  def password_property
+    :appSource
+  end
+
+  def sub_property_name
+    'Password'
+  end
+end

--- a/lib/cfn-nag/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule.rb
+++ b/lib/cfn-nag/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class OpsWorksAppSslConfigurationPrivateKeyRule < PasswordBaseRule
+  def rule_text
+    'OpsWorks App SslConfiguration PrivateKey must not be a plaintext ' \
+    'string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F61'
+  end
+
+  def resource_type
+    'AWS::OpsWorks::App'
+  end
+
+  def password_property
+    :sslConfiguration
+  end
+
+  def sub_property_name
+    'PrivateKey'
+  end
+end

--- a/lib/cfn-nag/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class OpsWorksStackCustomCookbooksSourcePasswordRule < PasswordBaseRule
+  def rule_text
+    'OpsWorks Stack CustomCookbooksSource Password must not be a plaintext ' \
+    'string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F62'
+  end
+
+  def resource_type
+    'AWS::OpsWorks::Stack'
+  end
+
+  def password_property
+    :customCookbooksSource
+  end
+
+  def sub_property_name
+    'Password'
+  end
+end

--- a/spec/custom_rules/OpsWorksAppAppSourcePasswordRule_spec.rb
+++ b/spec/custom_rules/OpsWorksAppAppSourcePasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::OpsWorks::App'
+password_property = 'AppSource'
+sub_property_name = 'Password'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::OpsWorks::App'
+password_property = 'SslConfiguration'
+sub_property_name = 'PrivateKey'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule_spec.rb
+++ b/spec/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::OpsWorks::Stack'
+password_property = 'CustomCookbooksSource'
+sub_property_name = 'Password'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,14 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: b@dP@$sW0rD
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_secrets_manager.yaml
@@ -1,0 +1,14 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: '{{resolve:secretsmanager:/opsworks/app/appsource_password:SecretString:password}}'
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_secure_systems_manager.yaml
@@ -1,0 +1,14 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_from_systems_manager.yaml
@@ -1,0 +1,14 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_not_set.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_not_set.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  OpsWorksAppAppSourcePassword:
+    Type: String
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: !Ref OpsWorksAppAppSourcePassword
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_with_noecho.yaml
@@ -1,0 +1,18 @@
+---
+Parameters:
+  OpsWorksAppAppSourcePassword:
+    Type: String
+    NoEcho: True
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: !Ref OpsWorksAppAppSourcePassword
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_app_source_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,19 @@
+---
+Parameters:
+  OpsWorksAppAppSourcePassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      AppSource: 
+        Type: git
+        Url: git://github.com/foo/bar.git
+        Revision: v1.0.0
+        Password: !Ref OpsWorksAppAppSourcePassword
+        Username: admin   
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: b@dPr1V@73K3y
+      StackId: Stack-Foo
+      Type: static
+  

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_secrets_manager.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: '{{resolve:secretsmanager:/opsworks/app/sslconfiguration_privatekey:SecretString:password}}'
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_secure_systems_manager.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: '{{resolve:ssm-secure:SecureSecretString:1}}'
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_from_systems_manager.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: '{{resolve:ssm:UnsecureSecretString:1}}'
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_not_set.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_not_set.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  OpsWorksAppSslConfigurationPrivateKey:
+    Type: String
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: !Ref OpsWorksAppSslConfigurationPrivateKey
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_with_noecho.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  OpsWorksAppSslConfigurationPrivateKey:
+    Type: String
+    NoEcho: True
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: !Ref OpsWorksAppSslConfigurationPrivateKey
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/opsworks_app/opsworks_app_ssl_configuration_private_key_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  OpsWorksAppSslConfigurationPrivateKey:
+    Type: String
+    NoEcho: True
+    Default: b@dPr1V@73K3y
+Resources:
+  OpsWorksApp:
+    Type: AWS::OpsWorks::App
+    Properties:
+      Name: foobar
+      SslConfiguration:
+        Certificate: Certificate-Foo
+        Chain: Chain-Bar
+        PrivateKey: !Ref OpsWorksAppSslConfigurationPrivateKey
+      StackId: Stack-Foo
+      Type: static

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: b@dP@$sW0rD
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_secrets_manager.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: '{{resolve:secretsmanager:/opsworks/stack/customcookbookssource_password:SecretString:password}}'
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_secure_systems_manager.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_from_systems_manager.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_not_set.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_not_set.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,14 @@
+---
+Parameters:
+  OpsWorksStackCustomCookbooksSourcePassword:
+    Type: String
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: !Ref OpsWorksStackCustomCookbooksSourcePassword
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_with_noecho.yaml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  OpsWorksStackCustomCookbooksSourcePassword:
+    Type: String
+    NoEcho: True
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: !Ref OpsWorksStackCustomCookbooksSourcePassword
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar

--- a/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/opsworks_stack/opsworks_stack_custom_cookbooks_source_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  OpsWorksStackCustomCookbooksSourcePassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  OpsWorksStack:
+    Type: AWS::OpsWorks::Stack
+    Properties:
+      CustomCookbooksSource:
+        Password: !Ref OpsWorksStackCustomCookbooksSourcePassword
+        Username: admin
+      DefaultInstanceProfileArn: arn:aws:iam::123456789012:instance-profile/MyProfile-foobar
+      Name: foobar
+      ServiceRoleArn: arn:aws:iam::123456789012:role/MyRole-foobar


### PR DESCRIPTION
Partial for #253 

Creates rule for the following resource properties:
* AWS::OpsWorks::Stack.Source Password
* AWS::OpsWorks::App.SslConfiguration PrivateKey
* AWS::OpsWorks::App.Source Password