### PR TITLE
Feature/253 emr cluster kerberos attributes password rules

### DIFF
--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule.rb
@@ -6,7 +6,7 @@ require_relative 'password_base_rule'
 class EMRClusterKerberosAttributesADDomainJoinPasswordRule < PasswordBaseRule
   def rule_text
     'EMR Cluster KerberosAttributes AD Domain JoinPassword must not be a ' \
-    'plaintext string or a Ref to a NoEcho Parameter with a Default value.' \
+    'plaintext string or a Ref to a NoEcho Parameter with a Default value.'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class EMRClusterKerberosAttributesADDomainJoinPasswordRule < PasswordBaseRule
+  def rule_text
+    'EMR Cluster KerberosAttributes AD Domain JoinPassword must not be a ' \
+    'plaintext string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F63'
+  end
+
+  def resource_type
+    'AWS::EMR::Cluster'
+  end
+
+  def password_property
+    :kerberosAttributes
+  end
+
+  def sub_property_name
+    'ADDomainJoinPassword'
+  end
+end

--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule < PasswordBaseRule
+  def rule_text
+    'EMR Cluster KerberosAttributes CrossRealmTrustPrincipal Password must ' \
+    'not be a plaintext string or a Ref to a NoEcho Parameter with a ' \
+    'Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F64'
+  end
+
+  def resource_type
+    'AWS::EMR::Cluster'
+  end
+
+  def password_property
+    :kerberosAttributes
+  end
+
+  def sub_property_name
+    'CrossRealmTrustPrincipalPassword'
+  end
+end

--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule.rb
@@ -7,7 +7,7 @@ class EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule < Passwor
   def rule_text
     'EMR Cluster KerberosAttributes CrossRealmTrustPrincipal Password must ' \
     'not be a plaintext string or a Ref to a NoEcho Parameter with a ' \
-    'Default value.' \
+    'Default value.'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule.rb
@@ -6,7 +6,7 @@ require_relative 'password_base_rule'
 class EMRClusterKerberosAttributesKdcAdminPasswordRule < PasswordBaseRule
   def rule_text
     'EMR Cluster KerberosAttributes KdcAdmin Password must not be a ' \
-    'plaintext string or a Ref to a NoEcho Parameter with a Default value.' \
+    'plaintext string or a Ref to a NoEcho Parameter with a Default value.'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule.rb
+++ b/lib/cfn-nag/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'password_base_rule'
+
+class EMRClusterKerberosAttributesKdcAdminPasswordRule < PasswordBaseRule
+  def rule_text
+    'EMR Cluster KerberosAttributes KdcAdmin Password must not be a ' \
+    'plaintext string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F65'
+  end
+
+  def resource_type
+    'AWS::EMR::Cluster'
+  end
+
+  def password_property
+    :kerberosAttributes
+  end
+
+  def sub_property_name
+    'KdcAdminPassword'
+  end
+end

--- a/spec/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::EMR::Cluster'
+password_property = 'KerberosAttributes'
+sub_property_name = 'ADDomainJoinPassword'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::EMR::Cluster'
+password_property = 'KerberosAttributes'
+sub_property_name = 'CrossRealmTrustPrincipalPassword'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::EMR::Cluster'
+password_property = 'KerberosAttributes'
+sub_property_name = 'KdcAdminPassword'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: b@dP@$sW0rD
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_secrets_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: '{{resolve:secretsmanager:/emr/cluster/kerberosattributes_addomainjoinpassword:SecretString:password}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_secure_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_from_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_not_set.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_not_set.yaml
@@ -1,0 +1,22 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,26 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesADDomainJoinPassword:
+    Type: String
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: !Ref EMRClusterKerberosAttributesADDomainJoinPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_with_noecho.yaml
@@ -1,0 +1,27 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesADDomainJoinPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: !Ref EMRClusterKerberosAttributesADDomainJoinPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_addomain_join_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,28 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesADDomainJoinPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        ADDomainJoinPassword: !Ref EMRClusterKerberosAttributesADDomainJoinPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: b@dP@$sW0rD
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_secrets_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: '{{resolve:secretsmanager:/emr/cluster/kerberosattributes_crossrealmtrustprincipalpassword:SecretString:password}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_secure_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_from_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_not_set.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_not_set.yaml
@@ -1,0 +1,22 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,26 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword:
+    Type: String
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: !Ref EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_with_noecho.yaml
@@ -1,0 +1,27 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: !Ref EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_cross_realm_trust_principal_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,28 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        CrossRealmTrustPrincipalPassword: !Ref EMRClusterKerberosAttributesCrossRealmTrustPrincipalPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: b@dP@$sW0rD
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_secrets_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: '{{resolve:secretsmanager:/emr/cluster/kerberosattributes_kdcadminpassword:SecretString:password}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_secure_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: '{{resolve:ssm-secure:SecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_from_systems_manager.yaml
@@ -1,0 +1,23 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: '{{resolve:ssm:UnsecureSecretString:1}}'
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_not_set.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_not_set.yaml
@@ -1,0 +1,22 @@
+---
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,26 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesKdcAdminPassword:
+    Type: String
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: !Ref EMRClusterKerberosAttributesKdcAdminPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_with_noecho.yaml
@@ -1,0 +1,27 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesKdcAdminPassword:
+    Type: String
+    NoEcho: True
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: !Ref EMRClusterKerberosAttributesKdcAdminPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar

--- a/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/emr_cluster/emr_cluster_kerberos_attributes_kdc_admin_password_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,28 @@
+---
+Parameters:
+  EMRClusterKerberosAttributesKdcAdminPassword:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  EMRCluster:
+    Type: AWS::EMR::Cluster
+    Properties:
+      Instances:
+        MasterInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: master_foobar
+        CoreInstanceGroup:
+          InstanceCount: 1
+          InstanceType: t2.micro
+          Market: ON_DEMAND
+          Name: core_foobar
+        Ec2SubnetId: subnet-foobar
+      Name: foobar
+      JobFlowRole: arn:aws:iam::123456789012:role/service-role/JobFlowRole-foobar
+      KerberosAttributes:
+        KdcAdminPassword: !Ref EMRClusterKerberosAttributesKdcAdminPassword
+        Realm: EC2.INTERNAL
+      ServiceRole: arn:aws:iam::123456789012:role/service-role/ServiceRole-foobar


### PR DESCRIPTION
Partial for #253 

Creates rule for the following resource properties:
* AWS::EMR::Cluster.KerberosAttributes ADDomainJoinPassword
* AWS::EMR::Cluster.KerberosAttributes CrossRealmTrustPrincipalPassword
* AWS::EMR::Cluster.KerberosAttributes KdcAdminPassword
