### PR TITLE
Feature/253 media live password rules

### DIFF
--- a/lib/cfn-nag/custom_rules/MediaLiveChannelOutputDestinationSettingsPasswordParamRule.rb
+++ b/lib/cfn-nag/custom_rules/MediaLiveChannelOutputDestinationSettingsPasswordParamRule.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class MediaLiveChannelOutputDestinationSettingsPasswordParamRule < BaseRule
+  def rule_text
+    'MediaLive Channel OutputDestinationSettings PasswordParam must not be a ' \
+    'plaintext string or a Ref to a NoEcho Parameter with a Default value.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F73'
+  end
+
+  def audit_impl(cfn_model)
+    media_live_channels = cfn_model.resources_by_type('AWS::MediaLive::Channel')
+    violating_channels = media_live_channels.select do |channel|
+      violating_destinations?(cfn_model, channel)
+    end
+
+    violating_channels.map(&:logical_resource_id)
+  end
+
+  private
+
+  def violating_destinations?(cfn_model, channel)
+    if !channel.destinations.nil?
+      violating_destination = channel.destinations.select do |destination|
+        violating_settings?(cfn_model, destination)
+      end
+      !violating_destination.empty?
+    else
+      false
+    end
+  end
+
+  def violating_settings?(cfn_model, destination)
+    if !destination['Settings'].nil?
+      violating_setting = destination['Settings'].select do |parameter|
+        channel_has_insecure_parameter?(cfn_model, parameter)
+      end
+      !violating_setting.empty?
+    else
+      false
+    end
+  end
+
+  def channel_has_insecure_parameter?(cfn_model, parameter)
+    if parameter['PasswordParam'].nil?
+      false
+    else
+      insecure_parameter?(cfn_model, parameter['PasswordParam']) ||
+        insecure_string_or_dynamic_reference?(cfn_model, parameter['PasswordParam'])
+    end
+  end
+end

--- a/lib/cfn-nag/custom_rules/MediaLiveInputSourcesPasswordParamRule.rb
+++ b/lib/cfn-nag/custom_rules/MediaLiveInputSourcesPasswordParamRule.rb
@@ -6,7 +6,7 @@ require_relative 'sub_property_with_list_password_base_rule'
 class MediaLiveInputSourcesPasswordParamRule < SubPropertyWithListPasswordBaseRule
   def rule_text
     'MediaLive Input Sources PasswordParam must not be a plaintext ' \
-    'string or a Ref to a NoEcho Parameter with a Default value.' \
+    'string or a Ref to a NoEcho Parameter with a Default value.'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/MediaLiveInputSourcesPasswordParamRule.rb
+++ b/lib/cfn-nag/custom_rules/MediaLiveInputSourcesPasswordParamRule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'sub_property_with_list_password_base_rule'
+
+class MediaLiveInputSourcesPasswordParamRule < SubPropertyWithListPasswordBaseRule
+  def rule_text
+    'MediaLive Input Sources PasswordParam must not be a plaintext ' \
+    'string or a Ref to a NoEcho Parameter with a Default value.' \
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'F72'
+  end
+
+  def resource_type
+    'AWS::MediaLive::Input'
+  end
+
+  def password_property
+    :sources
+  end
+
+  def sub_property_name
+    'PasswordParam'
+  end
+end

--- a/spec/custom_rules/MediaLiveChannelOutputDestinationSettingsPasswordParamRule_spec.rb
+++ b/spec/custom_rules/MediaLiveChannelOutputDestinationSettingsPasswordParamRule_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/MediaLiveChannelOutputDestinationSettingsPasswordParamRule'
+
+describe MediaLiveChannelOutputDestinationSettingsPasswordParamRule, :rule do
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam not set' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam parameter with NoEcho' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_parameter_with_noecho.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam parameter with NoEcho and Default value' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_parameter_with_noecho_and_default_value.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MediaLiveChannel]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam parameter as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_parameter_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MediaLiveChannel]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam as a literal in plaintext' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_as_a_literal_in_plaintext.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MediaLiveChannel]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam from Secrets Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_from_secrets_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam from Secure Systems Manager' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_from_secure_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'MediaLive Channel OutputDestinationSettings PasswordParam from Systems Manager' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/medialive_channel/' \
+        'media_live_channel_output_destination_settings_password_param_from_systems_manager.yaml'
+      )
+
+      actual_logical_resource_ids =
+        MediaLiveChannelOutputDestinationSettingsPasswordParamRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[MediaLiveChannel]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/custom_rules/MediaLiveInputSourcesPasswordParamRule_spec.rb
+++ b/spec/custom_rules/MediaLiveInputSourcesPasswordParamRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::MediaLive::Input'
+password_property = 'Sources'
+sub_property_name = 'PasswordParam'
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, password_property, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, password_property, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the password_rule_test_sets hash
+  password_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{password_property} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, password_property, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: b@dP@$sW0rD
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_secrets_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: '{{resolve:secretsmanager:/medialive/channel/destinations_settings_passwordparam:SecretString:password}}'
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_secure_systems_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: '{{resolve:ssm-secure:SecureSecretString:1}}'
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_from_systems_manager.yaml
@@ -1,0 +1,13 @@
+---
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: '{{resolve:ssm:UnsecureSecretString:1}}'
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_not_set.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_not_set.yaml
@@ -1,0 +1,12 @@
+---
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,16 @@
+---
+Parameters:
+  MediaLiveChannelDestinationsSettingsPasswordParam:
+    Type: String
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: !Ref MediaLiveChannelDestinationsSettingsPasswordParam
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_with_noecho.yaml
@@ -1,0 +1,17 @@
+---
+Parameters:
+  MediaLiveChannelDestinationsSettingsPasswordParam:
+    Type: String
+    NoEcho: True
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: !Ref MediaLiveChannelDestinationsSettingsPasswordParam
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/medialive_channel/media_live_channel_output_destination_settings_password_param_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,18 @@
+---
+Parameters:
+  MediaLiveChannelDestinationsSettingsPasswordParam:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  MediaLiveChannel:
+    Type: AWS::MediaLive::Channel
+    Properties:
+      ChannelClass: SINGLE_PIPELINE
+      Destinations:
+        - Id: foo
+          Settings:
+            - PasswordParam: !Ref MediaLiveChannelDestinationsSettingsPasswordParam
+              Username: admin
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Channel-foobar
+      Name: foobar

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: b@dP@$sW0rD
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_secrets_manager.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_secrets_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: '{{resolve:secretsmanager:/medialive/input/sources_passwordparam:SecretString:password}}'
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_secure_systems_manager.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_secure_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: '{{resolve:ssm-secure:SecureSecretString:1}}'
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_systems_manager.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_from_systems_manager.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: '{{resolve:ssm:UnsecureSecretString:1}}'
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_not_set.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_not_set.yaml
@@ -1,0 +1,9 @@
+---
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_as_a_literal_in_plaintext.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_as_a_literal_in_plaintext.yaml
@@ -1,0 +1,13 @@
+---
+Parameters:
+  MediaLiveInputSourcesPasswordParam:
+    Type: String
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: !Ref MediaLiveInputSourcesPasswordParam
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_with_noecho.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_with_noecho.yaml
@@ -1,0 +1,14 @@
+---
+Parameters:
+  MediaLiveInputSourcesPasswordParam:
+    Type: String
+    NoEcho: True
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: !Ref MediaLiveInputSourcesPasswordParam
+          Username: admin

--- a/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_with_noecho_and_default_value.yaml
+++ b/spec/test_templates/yaml/medialive_input/medialive_input_sources_password_param_parameter_with_noecho_and_default_value.yaml
@@ -1,0 +1,15 @@
+---
+Parameters:
+  MediaLiveInputSourcesPasswordParam:
+    Type: String
+    NoEcho: True
+    Default: b@dP@$sW0rD
+Resources:
+  MediaLiveInput:
+    Type: AWS::MediaLive::Input
+    Properties:
+      Name: foobar
+      RoleArn: arn:aws:iam::123456789012:role/MediaLive-Input-foobar
+      Sources:
+        - PasswordParam: !Ref MediaLiveInputSourcesPasswordParam
+          Username: admin


### PR DESCRIPTION
Partial for #253 

Creates rule for the following resource properties:
* AWS::MediaLive::Channel.OutputDestinationSettings PasswordParam
* AWS::MediaLive::Input.InputSourceRequest PasswordParam