### PR TITLE
Feature/60 elbv2 listener ssl policy rules

### DIFF
--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
@@ -3,9 +3,9 @@
 require 'cfn-nag/violation'
 require_relative 'base'
 
-class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
+class ElasticLoadBalancerV2ListenerProtocolRule < BaseRule
   def rule_text
-    'Elastic Load Balancer V2 Listener SslPolicy should use TLS 1.2'
+    'Elastic Load Balancer V2 Listener Protocol should use HTTPS for ALB or TLS for Network LB'
   end
 
   def rule_type
@@ -13,16 +13,13 @@ class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
   end
 
   def rule_id
-    'W77'
+    'W78'
   end
 
   def audit_impl(cfn_model)
     violating_listeners = cfn_model.resources_by_type('AWS::ElasticLoadBalancingV2::Listener')
                                    .select do |listener|
-      listener.sSLPolicy.nil? ||
-        %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
-           ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
-          .include?(listener.sSLPolicy)
+      listener.protocol == 'HTTP'
     end
 
     violating_listeners.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
@@ -13,7 +13,7 @@ class ElasticLoadBalancerV2ListenerProtocolRule < BaseRule
   end
 
   def rule_id
-    'W78'
+    'W56'
   end
 
   def audit_impl(cfn_model)

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 
 class ElasticLoadBalancerV2ListenerProtocolRule < BaseRule
   def rule_text
-    'Elastic Load Balancer V2 Listener Protocol should use HTTPS for ALB or TLS for Network LB'
+    'Elastic Load Balancer V2 Listener Protocol should use HTTPS for ALBs'
   end
 
   def rule_type

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
@@ -19,7 +19,6 @@ class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
   def audit_impl(cfn_model)
     violating_listeners = cfn_model.resources_by_type('AWS::ElasticLoadBalancingV2::Listener')
                                    .select do |listener|
-      listener.sSLPolicy.nil? ||
         %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
            ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
           .include?(listener.sSLPolicy)

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
+  def rule_text
+    'Elastic Load Balancer V2 Listener SslPolicy should use TLS 1.2'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W77'
+  end
+
+  def audit_impl(cfn_model)
+    violating_listeners = cfn_model.resources_by_type('AWS::ElasticLoadBalancingV2::Listener')
+                                   .select do |listener|
+      if listener.protocol == 'HTTPS' || listener.protocol == 'TLS'
+        listener.sslPolicy.nil? ||
+          %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
+             ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
+            .include?(listener.sslPolicy)
+      else
+        next
+      end
+    end
+
+    violating_listeners.map(&:logical_resource_id)
+  end
+end

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
@@ -13,7 +13,7 @@ class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
   end
 
   def rule_id
-    'W77'
+    'W55'
   end
 
   def audit_impl(cfn_model)

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
@@ -19,11 +19,23 @@ class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
   def audit_impl(cfn_model)
     violating_listeners = cfn_model.resources_by_type('AWS::ElasticLoadBalancingV2::Listener')
                                    .select do |listener|
-      %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
-         ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
-        .include?(listener.sSLPolicy)
+      violating_listeners?(listener)
     end
 
     violating_listeners.map(&:logical_resource_id)
+  end
+
+  private
+
+  def violating_listeners?(listener)
+    if %w[HTTPS TLS].include?(listener.protocol)
+      listener.sSLPolicy.nil? ||
+        %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04
+           ELBSecurityPolicy-TLS-1-1-2017-01 ELBSecurityPolicy-FS-2018-06
+           ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
+          .include?(listener.sSLPolicy)
+    else
+      false
+    end
   end
 end

--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule.rb
@@ -19,9 +19,9 @@ class ElasticLoadBalancerV2ListenerSslPolicyRule < BaseRule
   def audit_impl(cfn_model)
     violating_listeners = cfn_model.resources_by_type('AWS::ElasticLoadBalancingV2::Listener')
                                    .select do |listener|
-        %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
-           ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
-          .include?(listener.sSLPolicy)
+      %w[ELBSecurityPolicy-2016-08 ELBSecurityPolicy-TLS-1-0-2015-04 ELBSecurityPolicy-TLS-1-1-2017-01
+         ELBSecurityPolicy-FS-2018-06 ELBSecurityPolicy-FS-1-1-2019-08 ELBSecurityPolicy-2015]
+        .include?(listener.sSLPolicy)
     end
 
     violating_listeners.map(&:logical_resource_id)

--- a/spec/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule_spec.rb
+++ b/spec/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerProtocolRule'
+
+describe ElasticLoadBalancerV2ListenerProtocolRule do
+  context 'listener with an HTTP protocol' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_http_protocol.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerProtocolRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[HTTPlistener]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'listener with an HTTPS protocol' do
+    it 'returns an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_ssl_policy.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerProtocolRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule_spec.rb
+++ b/spec/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule_spec.rb
@@ -28,4 +28,30 @@ describe ElasticLoadBalancerV2ListenerSslPolicyRule do
       expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
     end
   end
+
+  context 'listener with HTTPS protocol missing ssl policy' do
+    it 'returns the default offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_and_no_ssl_policy.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerSslPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[HTTPSlistener]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'listener with HTTP protocol missing ssl policy' do
+    it 'returns an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_and_no_ssl_policy.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerSslPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
 end

--- a/spec/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule_spec.rb
+++ b/spec/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/ElasticLoadBalancerV2ListenerSslPolicyRule'
+
+describe ElasticLoadBalancerV2ListenerSslPolicyRule do
+  context 'listener with a pre-TLS 1.2 ssl policy' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_ssl_policy.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerSslPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[HTTPSlistener]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'listener with a TLS 1.2 ssl policy' do
+    it 'returns an empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_ssl_policy.yml'
+      )
+
+      actual_logical_resource_ids = ElasticLoadBalancerV2ListenerSslPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_and_no_ssl_policy.yml
+++ b/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_and_no_ssl_policy.yml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  HTTPSlistener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      Certificates:
+        - CertificateArn: "MyCertificateArn"
+      DefaultActions:
+        - Type: "forward"
+        - TargetGroupArn: "MyTargetGroupArn"
+      LoadBalancerArn: "MyLoadBalancerArn"
+      Port: 443
+      Protocol: "HTTPS"

--- a/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_ssl_policy.yml
+++ b/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_TLS_1_2_ssl_policy.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  HTTPSlistener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      Certificates:
+        - CertificateArn: "MyCertificateArn"
+      DefaultActions:
+        - Type: "forward"
+        - TargetGroupArn: "MyTargetGroupArn"
+      LoadBalancerArn: "MyLoadBalancerArn"
+      Port: 443
+      Protocol: "HTTPS"
+      SSLPolicy: "ELBSecurityPolicy-FS-1-2-2019-08"

--- a/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_http_protocol.yml
+++ b/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_http_protocol.yml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  HTTPlistener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      DefaultActions:
+        - Type: "forward"
+        - TargetGroupArn: "MyTargetGroupArn"
+      LoadBalancerArn: "MyLoadBalancerArn"
+      Port: 80
+      Protocol: "HTTP"

--- a/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_and_no_ssl_policy.yml
+++ b/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_and_no_ssl_policy.yml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  HTTPSlistener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      Certificates:
+        - CertificateArn: "MyCertificateArn"
+      DefaultActions:
+        - Type: "forward"
+        - TargetGroupArn: "MyTargetGroupArn"
+      LoadBalancerArn: "MyLoadBalancerArn"
+      Port: 80
+      Protocol: "HTTP"

--- a/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_ssl_policy.yml
+++ b/spec/test_templates/yaml/elasticloadbalacingv2_listener/listener_with_pre_TLS_1_2_ssl_policy.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  HTTPSlistener:
+    Type: "AWS::ElasticLoadBalancingV2::Listener"
+    Properties:
+      Certificates:
+        - CertificateArn: "MyCertificateArn"
+      DefaultActions:
+        - Type: "forward"
+        - TargetGroupArn: "MyTargetGroupArn"
+      LoadBalancerArn: "MyLoadBalancerArn"
+      Port: 443
+      Protocol: "HTTPS"
+      SSLPolicy: "ELBSecurityPolicy-2016-08"


### PR DESCRIPTION
Address issue 60:  https://github.com/stelligent/cfn_nag/issues/60

- Adds rule to warn when using an SSL Policy for an ELB v2 Listener that is not for TLS 1.2
- Adds rule to warn when using a Protocol of HTTP for an ELB v2 Listener (since we should be generally using HTTPS for an ALB where possible)
- Adds applicable spec tests and test template files