### PR TITLE
Updating deprecated 'version' property to 'ruby-version' for setup-ruby action

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby 2.5
       uses: actions/setup-ruby@v1
       with:
-        version: 2.5.x
+        ruby-version: 2.5.x
     - name: Install Bundler
       run: gem install bundler
     - name: Which bundler?
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Ruby 2.5
       uses: actions/setup-ruby@v1
       with:
-        version: 2.5.x
+        ruby-version: 2.5.x
     - name: Install Bundler
       run: gem install bundler
     - name: e2e
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Ruby 2.5
         uses: actions/setup-ruby@v1
         with:
-          version: 2.5.x
+          ruby-version: 2.5.x
       - name: Publish to RubyGems and DockerHub
         run: bash ./scripts/publish.sh
         env:


### PR DESCRIPTION
### Description
As of October 1, 2019 the `version` property of the [setup-ruby](https://github.com/actions/setup-ruby) action was deprecated and replaced by `ruby-version`.  This PR updates all instances of `version` to `ruby-version` in [gempush.yml](.github/workflows/gempush.yml).

### Testing
1. Committed changes to my personal fork and ran GitHub Workflow to ensure warnings did not appear.  **Note:** Please disregard the error showing in the tests; this is a side effect of running the Workflow in my personal fork.

Before:
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/4969682/73668373-c647d080-4673-11ea-8e28-7ef913ff4fbb.png">

After:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/4969682/73668450-de1f5480-4673-11ea-9f14-7f3fdf60e3d9.png">