### PR TITLE
Feature/369 adjust vscode container build and deploy

### DIFF
--- a/.github/workflows/vscode_remote_development.yml
+++ b/.github/workflows/vscode_remote_development.yml
@@ -1,0 +1,33 @@
+name: VS Code DockerHub Build & Push
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.devcontainer/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: checkout
+        uses: actions/checkout@master
+      -
+        name: docker login
+        env:
+          DOCKER_USER: ${{ secrets.docker_user }}
+          DOCKER_PASSWORD: ${{ secrets.docker_password }}
+        run: |
+          echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+      -
+        name: Build & Push to DockerHub
+        env:
+          DOCKER_ORG: stelligent
+          DOCKER_REPO: vscode-remote-cfn_nag
+        run: |
+          docker build -t $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8} --file .devcontainer/build/Dockerfile .
+          docker tag $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8} $DOCKER_ORG/$DOCKER_REPO:latest
+          docker push $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8}
+          docker push $DOCKER_ORG/$DOCKER_REPO:latest

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -82,11 +82,3 @@ docker tag $docker_org/cfn_nag:${new_version} $docker_org/cfn_nag:latest
 docker push $docker_org/cfn_nag:${new_version}
 docker push $docker_org/cfn_nag:latest
 
-# publish vscode-remote docker image to DockerHub, https://hub.docker.com/r/stelligent/vscode-remote-cfn_nag
-docker build -t $docker_org/vscode-remote-cfn_nag:${new_version} --file .devcontainer/build/Dockerfile .
-set +x
-echo $docker_password | docker login -u $docker_user --password-stdin
-set -x
-docker tag $docker_org/vscode-remote-cfn_nag:${new_version} $docker_org/vscode-remote-cfn_nag:latest
-docker push $docker_org/vscode-remote-cfn_nag:${new_version}
-docker push $docker_org/vscode-remote-cfn_nag:latest

--- a/vscode_remote_development.md
+++ b/vscode_remote_development.md
@@ -11,7 +11,7 @@ You can start working on developing with this project with relative ease by usin
 
 ### Docker Hub: stelligent/vscode-remote-cfn_nag
 
-The main `.devcontainer/Dockerfile` points to the latest `stelligent/vscode-remote-cfn_nag` Docker Hub container image. This image is created and pushed by a step in the `scripts/publish.sh` file. This will build a new remote development container image and tag it with the same `cfn_nag` gem version.
+The main `.devcontainer/Dockerfile` points to the latest `stelligent/vscode-remote-cfn_nag` Docker Hub container image. This image is created and pushed by a separate GitHub Actions Workflow. It will tag the newly created image with the short git sha and `latest`.
 
 ### Build Dockerfile
 


### PR DESCRIPTION
Closes #369 

Changes the update procedure for the `stelligent/vscode-remote-cfn_nag` DockerHub repo. It will now only build and push an image if something inside the `.devcontainer/` directory is updated in the master branch. This is made available by implementing a new GitHub Actions Workflow, replacing the old build and push items from within the `scripts/publish.sh` file.