### PR TITLE
#368 changing ssh and gpg to be mounted as a volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,13 +11,15 @@
 		// Bash History
 		"source=cfn_nag-bash_history,target=/commandhistory,type=volume",
 		// Docker in Docker
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	],
+	"runArgs": [
 		// SSH
-		"source=${localEnv:HOME}/.ssh,target=/home/cfn_nag_dev/.ssh,type=bind,readonly",
+		"-v", "${localEnv:HOME}/.ssh:/home/cfn_nag_dev/.ssh:ro",
 		// GPG
-		"source=${localEnv:HOME}/.gnupg/private-keys-v1.d,target=/home/cfn_nag_dev/.gnupg/private-keys-v1.d,type=bind,readonly",
-		"source=${localEnv:HOME}/.gnupg/pubring.kbx,target=/home/cfn_nag_dev/.gnupg/pubring.kbx,type=bind,readonly",
-		"source=${localEnv:HOME}/.gnupg/trustdb.gpg,target=/home/cfn_nag_dev/.gnupg/trustdb.gpg,type=bind,readonly"
+		"-v", "${localEnv:HOME}/.gnupg/private-keys-v1.d:/home/cfn_nag_dev/.gnupg/private-keys-v1.d:ro",
+		"-v", "${localEnv:HOME}/.gnupg/pubring.kbx:/home/cfn_nag_dev/.gnupg/pubring.kbx:ro",
+		"-v", "${localEnv:HOME}/.gnupg/trustdb.gpg:/home/cfn_nag_dev/.gnupg/trustdb.gpg:ro"
 	],
 	"extensions": [
 		// General

--- a/vscode_remote_development.md
+++ b/vscode_remote_development.md
@@ -7,6 +7,17 @@ You can start working on developing with this project with relative ease by usin
 - When prompted "`Folder contains a dev container configuration file. Reopen folder to develop in a container`" click the "`Reopen in Container`" button
 - When opening in the future use the "`[Dev Container] cfn_nag Development`" option
 
+## VS Code Dependencies
+
+There are a couple of dependencies that you need to configure locally before being able to fully utizlize the Remote Developemnt environment.
+- Requires `ms-vscode-remote.remote-containers` >= `0.101.0`
+- [Docker](https://www.docker.com/products/docker-desktop)
+  - Needs to be installed in order to use the remote development container
+- [GPG](https://gpgtools.org)
+  - Should to be installed in `~/.gnupg/` to be able to sign git commits with gpg
+- SSH
+  - Should to be installed in `~/.ssh` to be able to use your ssh config and keys.
+
 ## Container Image
 
 ### Docker Hub: stelligent/vscode-remote-cfn_nag

--- a/vscode_remote_development.md
+++ b/vscode_remote_development.md
@@ -36,7 +36,7 @@ Some important items to note here:
 * Mounts:
   * A volume is created and mounted to store the `bash` command line history from within the container. Now when you close the connection and reopen at a later date, you can still search for previously used commands as needed.
   * The Docker socket is mounted so that you can still run `docker` commands from within the remote container environment.
-  * Your local ssh directory (`~/.ssh`) is mounted so that you still access your config and sshkeys to be able to connect to github with key authentication.
-  * Your local gpg items are mounted so that you can still sign your commits and tags from within the remote container.
+  * If it exists, your local ssh directory (`~/.ssh`) is mounted so that you still access your config and sshkeys to be able to connect to github with key authentication.
+  * If it exists, your local gpg items (`~/.gnupg`) are mounted so that you can still sign your commits and tags from within the remote container.
 * Several vscode extensions are installed to help the user jumping right into project development. These extensions also have custom configured settings to work within the remote container environment.
 * Runs `bundle install` so that everything is fully setup for the user before they get logged into the connection. The user can simply just run the `rake` commands without needing to set anything else up.


### PR DESCRIPTION
Closes #368 

Changes the requirement of having ssh and gpg as a requirement to use the VS Code Remote Development Container Environment. It now will mount these items using `--volume` instead of `--mount`, that way if the items don't exist locally, the container will still launch without error.
