### PR TITLE
init commit for issue 72 - API Gateway AuthType property - warning fo…

### DIFF
--- a/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
@@ -18,7 +18,7 @@ class ApiGatewayMethodAuthorizationTypeRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_deployments = cfn_model.resources_by_type('AWS::ApiGateway::Method').select do |method|
-      method.authorizationType.nil? || method.authorizationType.to_s.downcase == 'none'
+      method.authorizationType.to_s == '' || method.authorizationType.to_s.casecmp('none').zero?
     end
 
     violating_deployments.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
@@ -18,7 +18,7 @@ class ApiGatewayMethodAuthorizationTypeRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_deployments = cfn_model.resources_by_type('AWS::ApiGateway::Method').select do |method|
-      method.authorizationType.to_s == '' || method.authorizationType.to_s.casecmp('none').zero?
+      method.authorizationType.nil? || method.authorizationType.to_s.casecmp('none').zero?
     end
 
     violating_deployments.map(&:logical_resource_id)

--- a/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class ApiGatewayMethodAuthorizationTypeRule < BaseRule
+  def rule_text
+    "AWS::ApiGateway::Method should not have AuthorizationType set to 'NONE'. "
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W58'
+  end
+
+  def audit_impl(cfn_model)
+    violating_deployments = cfn_model.resources_by_type('AWS::ApiGateway::Method').select do |method|
+      method.authorizationType.nil? || method.authorizationType.to_s.downcase == 'none'
+    end
+
+    violating_deployments.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/ApiGatewayMethodAuthorizationTypeRule_spec.rb
+++ b/spec/custom_rules/ApiGatewayMethodAuthorizationTypeRule_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/ApiGatewayMethodAuthorizationTypeRule'
+
+describe ApiGatewayMethodAuthorizationTypeRule do
+  context "AWS::ApiGateway::Method has AuthorizationType set to NONE. " do
+    it 'Returns offending logical resource ids.' do
+      cfn_model = CfnParser.new.parse read_test_template(
+                                          'yaml/api_gateway/api_gateway_method_authorization_type_none.yaml'
+                                      )
+
+      actual_logical_resource_ids = ApiGatewayMethodAuthorizationTypeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayMethod1 ApiGatewayMethod2 ApiGatewayMethod3]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context "AWS::ApiGateway::Method has AuthorizationType set to any of the valid values. " do
+    it 'Returns an empty list.' do
+      cfn_model = CfnParser.new.parse read_test_template(
+                                          'yaml/api_gateway/api_gateway_method_authorization_type_valid_values.yaml'
+                                      )
+
+      actual_logical_resource_ids = ApiGatewayMethodAuthorizationTypeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context "AWS::ApiGateway::Method has AuthorizationType set to NONE with Default value param refs. " do
+    it 'Returns offending logical resource ids.' do
+      cfn_model = CfnParser.new.parse read_test_template(
+                                          'yaml/api_gateway/api_gateway_method_authorization_type_none_with_param_refs.yaml',
+                                      ),
+                                      parameter_values_json='[]'
+
+      actual_logical_resource_ids = ApiGatewayMethodAuthorizationTypeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayMethod1 ApiGatewayMethod2 ApiGatewayMethod3]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context "AWS::ApiGateway::Method has AuthorizationType set to any of the valid values with Default value param refs. " do
+    it 'Returns an empty list.' do
+      cfn_model = CfnParser.new.parse read_test_template(
+                                          'yaml/api_gateway/api_gateway_method_authorization_type_valid_values_with_param_refs.yaml',
+                                          ),
+                                      parameter_values_json='[]'
+
+      actual_logical_resource_ids = ApiGatewayMethodAuthorizationTypeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context "AWS::ApiGateway::Method has AuthorizationType is Nil. " do
+    it 'Returns offending logical resource ids.' do
+      cfn_model = CfnParser.new.parse read_test_template(
+                                          'yaml/api_gateway/api_gateway_method_authorization_type_nil_value.yaml'
+                                      )
+
+      actual_logical_resource_ids = ApiGatewayMethodAuthorizationTypeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayMethod1 ApiGatewayMethod2]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_nil_value.yaml
+++ b/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_nil_value.yaml
@@ -1,0 +1,11 @@
+---
+Resources:
+  ApiGatewayMethod1:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType:
+
+  ApiGatewayMethod2:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType:

--- a/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_none.yaml
+++ b/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_none.yaml
@@ -1,0 +1,16 @@
+---
+Resources:
+  ApiGatewayMethod1:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+
+  ApiGatewayMethod2:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: None
+
+  ApiGatewayMethod3:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: none

--- a/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_none_with_param_refs.yaml
+++ b/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_none_with_param_refs.yaml
@@ -1,0 +1,28 @@
+---
+Parameters:
+  ApiGatewayMethodAuthorizationType1:
+    Type: String
+    Default: NONE
+  ApiGatewayMethodAuthorizationType2:
+    Type: String
+    Default: None
+  ApiGatewayMethodAuthorizationType3:
+    Type: String
+    Default: none
+
+Resources:
+  ApiGatewayMethod1:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: !Ref ApiGatewayMethodAuthorizationType1
+
+  ApiGatewayMethod2:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType:
+        Ref: ApiGatewayMethodAuthorizationType2
+
+  ApiGatewayMethod3:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: !Ref ApiGatewayMethodAuthorizationType3

--- a/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_valid_values.yaml
+++ b/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_valid_values.yaml
@@ -1,0 +1,16 @@
+---
+Resources:
+  ApiGatewayMethod1:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: AWS_IAM
+
+  ApiGatewayMethod2:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: CUSTOM
+
+  ApiGatewayMethod3:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: COGNITO_USER_POOLS

--- a/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_valid_values_with_param_refs.yaml
+++ b/spec/test_templates/yaml/api_gateway/api_gateway_method_authorization_type_valid_values_with_param_refs.yaml
@@ -1,0 +1,28 @@
+---
+Parameters:
+  ApiGatewayMethodAuthorizationType1:
+    Type: String
+    Default: AWS_IAM
+  ApiGatewayMethodAuthorizationType2:
+    Type: String
+    Default: CUSTOM
+  ApiGatewayMethodAuthorizationType3:
+    Type: String
+    Default: COGNITO_USER_POOLS
+
+Resources:
+  ApiGatewayMethod1:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: !Ref ApiGatewayMethodAuthorizationType1
+
+  ApiGatewayMethod2:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType:
+        Ref: ApiGatewayMethodAuthorizationType2
+
+  ApiGatewayMethod3:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: !Ref ApiGatewayMethodAuthorizationType3


### PR DESCRIPTION
Set a WARNING rule for AWS::ApiGateway::Method resource if `AuthorizationType` property is set to `NONE`. This property should be set to either of the following: `AWS_IAM`, `CUSTOM`, `COGNITO_USER_POOLS`. 