### PR TITLE
https://github.com/stelligent/cfn_nag/issues/383 ApiGateway Security

### DIFF
--- a/lib/cfn-nag/custom_rules/ApiGatewaySecurityPolicyRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewaySecurityPolicyRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class ApiGatewaySecurityPolicyRule < BaseRule
+  def rule_text
+    'ApiGateway SecurityPolicy should use TLS 1.2'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W62'
+  end
+
+  def audit_impl(cfn_model)
+    violating_domains = cfn_model.resources_by_type('AWS::ApiGateway::DomainName').select do |domain|      
+      domain.securityPolicy.nil? || domain.securityPolicy == 'TLS_1_0'
+    end
+
+    violating_domains.map(&:logical_resource_id)
+  end
+
+end

--- a/spec/custom_rules/ApiGatewaySecurityPolicyRule_spec.rb
+++ b/spec/custom_rules/ApiGatewaySecurityPolicyRule_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/ApiGatewaySecurityPolicyRule'
+
+describe ApiGatewaySecurityPolicyRule do
+  context 'Api Gateway has not TLS 1.2 configured since it missing SecurityPolicy' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/apigateway_securitypolicy/apigateway_without_securitypolicy.json')
+
+      actual_logical_resource_ids = ApiGatewaySecurityPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayWithoutSecurityPolicy]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Api Gateway have TLS 1.0 enabled' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/apigateway_securitypolicy/apigateway_with_tls_10.json')
+
+      actual_logical_resource_ids = ApiGatewaySecurityPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayWithTLS10]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Api Gateway have TLS 1.2 enabled' do
+    it 'returns empty' do
+      cfn_model = CfnParser.new.parse read_test_template('json/apigateway_securitypolicy/apigateway_with_tls_12.json')
+
+      actual_logical_resource_ids = ApiGatewaySecurityPolicyRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/json/apigateway_securitypolicy/apigateway_with_tls_10.json
+++ b/spec/test_templates/json/apigateway_securitypolicy/apigateway_with_tls_10.json
@@ -1,0 +1,10 @@
+{
+	"Resources": {
+		"ApiGatewayWithTLS10": {
+			"Type": "AWS::ApiGateway::DomainName",
+			"Properties": {
+				"SecurityPolicy": "TLS_1_0"
+			}
+		}
+	}
+}

--- a/spec/test_templates/json/apigateway_securitypolicy/apigateway_with_tls_12.json
+++ b/spec/test_templates/json/apigateway_securitypolicy/apigateway_with_tls_12.json
@@ -1,0 +1,10 @@
+{
+	"Resources": {
+		"ApiGatewayWithTls12": {
+			"Type": "AWS::ApiGateway::DomainName",
+			"Properties": {
+				"SecurityPolicy": "TLS_1_2"
+			}
+		}
+	}
+}

--- a/spec/test_templates/json/apigateway_securitypolicy/apigateway_without_securitypolicy.json
+++ b/spec/test_templates/json/apigateway_securitypolicy/apigateway_without_securitypolicy.json
@@ -1,0 +1,9 @@
+{
+	"Resources": {
+		"ApiGatewayWithoutSecurityPolicy": {
+			"Type": "AWS::ApiGateway::DomainName",
+			"Properties": {
+			}
+		}
+	}
+}


### PR DESCRIPTION
policy should use TLS 1.2.

Used W62 to account for 4 already created pull requests to avoid any conflict.