### PR TITLE
#394 Cleanup rspec output

### DIFF
--- a/spec/blacklist_loader_spec.rb
+++ b/spec/blacklist_loader_spec.rb
@@ -90,7 +90,7 @@ END
 
         expect do
           BlackListLoader.new(@rule_registry).load blacklist_definition: blacklist_definition
-        end.to raise_error # 'FAKEID is not a legal rule identifier'
+        end.to raise_error RuntimeError, /FAKEID1 is not a legal rule identifier/
       end
     end
 

--- a/spec/cfn_nag_integration/cfn_nag_executor_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_executor_spec.rb
@@ -4,6 +4,10 @@ require 'cfn-nag/cfn_nag_logging'
 require 'cfn-nag/cfn_nag_executor'
 
 describe CfnNagExecutor do
+  # Method of suppressing stderr and stdout was found on StackOverflow here:
+  # https://stackoverflow.com/a/22777806
+  original_stderr = nil
+  original_stdout = nil
 
   before(:all) do
     CfnNagLogging.configure_logging(debug: false)
@@ -17,6 +21,18 @@ describe CfnNagExecutor do
       output_format: 'json',
       rule_repository: []
     }
+
+    original_stderr = $stderr  # capture previous value of $stderr
+    original_stdout = $stdout  # capture previous value of $stdout
+    $stderr = StringIO.new     # assign a string buffer to $stderr
+    $stdout = StringIO.new     # assign a string buffer to $stdout
+    # $stderr.string             # return the contents of the string buffer if needed
+    # $stdout.string             # return the contents of the string buffer if needed
+  end
+
+  after(:all) do
+    $stderr = original_stderr  # restore $stderr to its previous value
+    $stdout = original_stdout  # restore $stdout to its previous value
   end
 
   context 'single file cfn_nag with fail on warnings' do

--- a/spec/profile_loader_spec.rb
+++ b/spec/profile_loader_spec.rb
@@ -60,7 +60,7 @@ describe ProfileLoader do
       it 'should raise an error' do
         expect do
           ProfileLoader.new(@rule_registry).load profile_definition: 'FAKEID1'
-        end.to raise_error # 'FAKEID is not a legal rule identifier'
+        end.to raise_error RuntimeError, /FAKEID1 is not a legal rule identifier/
       end
     end
 


### PR DESCRIPTION
Closes #394 

### Description

Currently when running all `rspec` tests for cfn_nag, there is close to 300 lines of output written to the screen (see Before section below).  This makes it difficult when debugging new rules.  By adding error types where needed and suppressing stderr/stdout from cfn_nag_executor calls, this PR will cleanup all erroneous `rspec` output.

### Testing

1. All `rspec` tests executed successfully before and after the changes.

#### Before

[rspec_output.txt](https://github.com/stelligent/cfn_nag/files/4281810/rspec_output.txt)

#### After

```
cfn_nag_dev@caefac1f2dd9:/workspaces/cfn_nag$ bundle exec rspec
Run options: exclude {:end_to_end=>true}
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
.........................................................................................................................

Finished in 8.43 seconds (files took 2.78 seconds to load)
697 examples, 0 failures

Coverage report generated for RSpec to /workspaces/cfn_nag/coverage. 2737 / 2826 LOC (96.85%) covered.
```