### PR TITLE
#191 Create GitHub releases with corresponding changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'hotfix'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'maintenance'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 env:
-  docker_org: stelligent
+  docker_org: pshelby
 
 jobs:
   commit:
@@ -57,10 +57,6 @@ jobs:
       - run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           git fetch --prune --unshallow
-      - name: Set up Ruby 2.5
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.5.x
       - name: Publish to RubyGems and DockerHub
         id: publish
         run: bash ./scripts/publish.sh
@@ -68,39 +64,48 @@ jobs:
           rubygems_api_key: ${{secrets.rubygems_api_key}}
           docker_user: ${{secrets.docker_user}}
           docker_password: ${{secrets.docker_password}}
-      - name: Create binary artifact
+      # - name: Create binary artifact
+      #   run: |
+      #     gem install cfn-nag
+      #     gem list
+      #     echo $GITHUB_REF
+      #     cd ${{ steps.publish.outputs.gem_exec_path }}
+      #     zip cfn_nag cfn_nag cfn_nag_rules cfn_nag_scan
+      - name: Create release with changelog
+        id: gh_release
+        uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          publish: true
+          version: ${{ steps.publish.outputs.cfn_nag_version }}
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # `upload_url` pulls from the CREATE RELEASE step above, referencing its ID to get the outputs object, which includes a `upload_url`.
+      #     # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: ${{ steps.publish.outputs.gem_exec_path }}/cfn_nag.zip
+      #     asset_name: cfn_nag.zip
+      #     asset_content_type: application/zip
+      - name: Trigger cfn_nag for CodePipeline SAR publish
         run: |
-          gem install cfn-nag
-          gem list
-          echo $GITHUB_REF
-          cd ${{ steps.publish.outputs.gem_exec_path }}
-          zip cfn_nag cfn_nag cfn_nag_rules cfn_nag_scan
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.publish.outputs.cfn_nag_version }}
-          release_name: v${{ steps.publish.outputs.cfn_nag_version }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # `upload_url` pulls from the CREATE RELEASE step above, referencing its ID to get the outputs object, which includes a `upload_url`.
-          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.publish.outputs.gem_exec_path }}/cfn_nag.zip
-          asset_name: cfn_nag.zip
-          asset_content_type: application/zip
+          curl -s \
+               -XPOST \
+               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
+               -H "Accept: application/vnd.github.everest-preview+json" \
+               -H "Content-Type: application/json" \
+               https://api.github.com/repos/${{ env.docker_org }}/cfn-nag-pipeline/dispatches \
+               --data '{"event_type": "build_application"}'
       - name: Trigger homebrew-tap repo workflow
         run: |
-          curl -s -XPOST -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" \
-          https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
-          --data '{"event_type": "build_application"}'
+          curl -s \
+               -XPOST \
+               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
+               -H "Accept: application/vnd.github.everest-preview+json" \
+               -H "Content-Type: application/json" \
+               https://api.github.com/repos/${{ env.docker_org }}/homebrew-tap/dispatches \
+               --data '{"event_type": "build_application"}'

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 env:
-  docker_org: pshelby
+  docker_org: stelligent
 
 jobs:
   commit:
@@ -64,13 +64,6 @@ jobs:
           rubygems_api_key: ${{secrets.rubygems_api_key}}
           docker_user: ${{secrets.docker_user}}
           docker_password: ${{secrets.docker_password}}
-      # - name: Create binary artifact
-      #   run: |
-      #     gem install cfn-nag
-      #     gem list
-      #     echo $GITHUB_REF
-      #     cd ${{ steps.publish.outputs.gem_exec_path }}
-      #     zip cfn_nag cfn_nag cfn_nag_rules cfn_nag_scan
       - name: Create release with changelog
         id: gh_release
         uses: release-drafter/release-drafter@master
@@ -79,18 +72,6 @@ jobs:
         with:
           publish: true
           version: ${{ steps.publish.outputs.cfn_nag_version }}
-      # - name: Upload Release Asset
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     # `upload_url` pulls from the CREATE RELEASE step above, referencing its ID to get the outputs object, which includes a `upload_url`.
-      #     # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: ${{ steps.publish.outputs.gem_exec_path }}/cfn_nag.zip
-      #     asset_name: cfn_nag.zip
-      #     asset_content_type: application/zip
       - name: Trigger cfn_nag for CodePipeline SAR publish
         run: |
           curl -s \

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -99,8 +99,10 @@ jobs:
           asset_content_type: application/zip
       - name: Trigger homebrew-tap repo workflow
         run: |
-          curl -s -XPOST -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Content-Type: application/json" \
-          https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
-          --data '{"event_type": "build_application"}'
+          curl -s \
+               -XPOST \
+               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
+               -H "Accept: application/vnd.github.everest-preview+json" \
+               -H "Content-Type: application/json" \
+               https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
+               --data '{"event_type": "build_application"}'

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -99,10 +99,8 @@ jobs:
           asset_content_type: application/zip
       - name: Trigger homebrew-tap repo workflow
         run: |
-          curl -s \
-               -XPOST \
-               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
-               -H "Accept: application/vnd.github.everest-preview+json" \
-               -H "Content-Type: application/json" \
-               https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
-               --data '{"event_type": "build_application"}'
+          curl -s -XPOST -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" \
+          https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
+          --data '{"event_type": "build_application"}'

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -62,26 +62,45 @@ jobs:
         with:
           ruby-version: 2.5.x
       - name: Publish to RubyGems and DockerHub
+        id: publish
         run: bash ./scripts/publish.sh
         env:
           rubygems_api_key: ${{secrets.rubygems_api_key}}
           docker_user: ${{secrets.docker_user}}
           docker_password: ${{secrets.docker_password}}
-      - name: Trigger cfn_nag for CodePipeline SAR publish
+      - name: Create binary artifact
         run: |
-          curl -s \
-               -XPOST \
-               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
-               -H "Accept: application/vnd.github.everest-preview+json" \
-               -H "Content-Type: application/json" \
-               https://api.github.com/repos/stelligent/cfn-nag-pipeline/dispatches \
-               --data '{"event_type": "build_application"}'
+          gem install cfn-nag
+          gem list
+          echo $GITHUB_REF
+          cd ${{ steps.publish.outputs.gem_exec_path }}
+          zip cfn_nag cfn_nag cfn_nag_rules cfn_nag_scan
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.publish.outputs.cfn_nag_version }}
+          release_name: v${{ steps.publish.outputs.cfn_nag_version }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # `upload_url` pulls from the CREATE RELEASE step above, referencing its ID to get the outputs object, which includes a `upload_url`.
+          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.publish.outputs.gem_exec_path }}/cfn_nag.zip
+          asset_name: cfn_nag.zip
+          asset_content_type: application/zip
       - name: Trigger homebrew-tap repo workflow
         run: |
-          curl -s \
-               -XPOST \
-               -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
-               -H "Accept: application/vnd.github.everest-preview+json" \
-               -H "Content-Type: application/json" \
-               https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
-               --data '{"event_type": "build_application"}'
+          curl -s -XPOST -u "cfn_nag-bot:${{secrets.homebrew_tap_bot}}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" \
+          https://api.github.com/repos/stelligent/homebrew-tap/dispatches \
+          --data '{"event_type": "build_application"}'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![cfn_nag](https://github.com/stelligent/cfn_nag/workflows/cfn_nag/badge.svg)
 
-# Background 
+# Background
 
 The cfn-nag tool looks for patterns in CloudFormation templates that may indicate insecure infrastructure.
 Roughly speaking, it will look for:
@@ -20,7 +20,7 @@ For more background on the tool, please see:
 
 # Installation
 
-## Gem Install 
+## Gem Install
 Presuming Ruby >= 2.5.x is installed, installation is just a matter of:
 
 ```bash
@@ -271,9 +271,9 @@ If the JSON is malformed or doesn't meet the above specification, then parsing w
 
 # Controlling the Behavior of Conditions
 
-Up until version 0.4.66 of cfn_nag, the underlying model did not do any processing of Fn::If within a template.  This meant that if a property had a conditional value, it was up to the rule to parse the Fn::If.  Given that an Fn::If could appear just about anywhere, it created a whack-a-mole situation for rule developers.  At best, the rule logic could ignore values that were Hash presuming the value wasn't a Hash in the first place.  
+Up until version 0.4.66 of cfn_nag, the underlying model did not do any processing of Fn::If within a template.  This meant that if a property had a conditional value, it was up to the rule to parse the Fn::If.  Given that an Fn::If could appear just about anywhere, it created a whack-a-mole situation for rule developers.  At best, the rule logic could ignore values that were Hash presuming the value wasn't a Hash in the first place.
 
-In order to address this issue, the default behavior for cfn_nag is now to substitute Fn::If with the true outcome.  This means by default that rules will not inspect the false outcomes for security violations.  
+In order to address this issue, the default behavior for cfn_nag is now to substitute Fn::If with the true outcome.  This means by default that rules will not inspect the false outcomes for security violations.
 
 In addition to substituting Fn::If at the property value level, the same behavior is applied to Fn::If at the top-level of Properties.  For example:
 
@@ -319,7 +319,7 @@ generalized such that custom rule repositories can be used to discover rules.
 1. A bunch of "rule files" sitting around on a filesystem isn't great from a traditional software development perspective.
 There is no version or traceability on these files, so 0.5.x introduces the notion of a "cfn_nag rule gem".  A developer
 can develop custom rules as part of a separate gem, version it and install it... and those rules are referenced from cfn_nag
-as long as the gem metadata includes `cfn_nag_rules => true`.  For a gem named like "cfn-nag-hipaa-rules", any \*.rb under 
+as long as the gem metadata includes `cfn_nag_rules => true`.  For a gem named like "cfn-nag-hipaa-rules", any \*.rb under
 lib/cfn-nag-hipaa-rules will be loaded.  Any custom rules should derive from CfnNag::BaseRule in cfn-nag/base_rule (*not* cfn-nag/custom-rules/base).  If the rule must derive from something else, defining a method `cfn_nag_rule?` that returns true will also cause it to be loaded as a rule.
 
 2. When cfn_nag is running in an AWS Lambda - there isn't really a filesystem (besides /tmp) in the traditional sense.
@@ -336,9 +336,9 @@ repo_class_name: S3BucketBasedRuleRepo
 repo_arguments:
   s3_bucket_name: cfn-nag-rules-my-enterprise
   prefix: /rules
-``` 
+```
 
-To apply *Rule.rb files in the bucket cfn-nag-rules-my-enterprise with the prefix /rules (e.g. /rules/MyNewRule.rb), 
+To apply *Rule.rb files in the bucket cfn-nag-rules-my-enterprise with the prefix /rules (e.g. /rules/MyNewRule.rb),
 specify this file on the command line to cfn_nag as such:
 
 ```yaml
@@ -348,7 +348,7 @@ cat my_cfn_template.yml | cfn_nag --rule-repository s3.yml
 If rules are in more than one bucket, then create multiple s3*.yml files and specify them in the `--rule-repository` argument.
 
 If the ambient AWS credentials have permission to access the bucket `cfn-nag-rules-enterprise` then it will find all rules
-like `/rules/*Rule.rb`. If a particular aws_profile should be used, add it as a key under `repo_arguments`, e.g 
+like `/rules/*Rule.rb`. If a particular aws_profile should be used, add it as a key under `repo_arguments`, e.g
 `aws_profile: my_aws_profile`
 
 Beyond the filesystem, gem installs and S3 - the new architecture theoretically supports developing other "rule repositories"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 set -o pipefail
+export minor_version="0.5"
 
 # set +x
 # if [[ -z ${rubygems_api_key} ]];
@@ -34,75 +35,29 @@ echo :rubygems_api_key: ${rubygems_api_key} > ~/.gem/credentials
 set -ex
 chmod 0600 ~/.gem/credentials
 
-# git describe returns the latest tag
-current_tag=$(git describe)
-echo "current_tag=$current_tag"
-
-# Check if '-' in git describe. If so, we
-# have advanced past the latest tag (and will
-# need to compute new version)
-tagged_commit=1
-if echo $current_tag | grep -q '-'; then
-  tagged_commit=0
-fi
-echo "tagged_commit=$tagged_commit"
-
-# strip off initial 'v' and everything after digits and .
-current_version=$(git describe | sed 's/^\(v\)\([0-9.]*\).*$/\2/')
-# strip .### from end to get major.minor version
-current_minor=$(echo $current_version | sed 's/\.\([0-9]*\)$//')
-# get third dotted field for patch version
-current_patch=$(echo $current_version | cut -f 3 -d . )
-echo "current_version=$current_version"
-git tag
+current_version=$(ruby -e 'tags=`git tag -l v#{ENV["minor_version"]}.*`' \
+                       -e 'p tags.lines.map { |tag| tag.sub(/v#{ENV["minor_version"]}./, "").chomp.to_i }.max')
 
 if [[ ${current_version} == nil ]];
 then
-  # No version determined from tag, assume 0.0.0
-  GEM_VERSION='0.0.0'
-elif [ $tagged_commit = 1 ]; then
-  # Current commit was tagged with version, use it
-  GEM_VERSION=$current_version
+  new_version="${minor_version}.0"
 else
-  # Current commit was goes past a tag, increment patch
-  GEM_VERSION="$current_minor."$((current_patch + 1))
+  new_version="${minor_version}.$((current_version+1))"
 fi
 
-export GEM_VERSION
+sed -i.bak "s/0\.0\.0/${new_version}/g" cfn-nag.gemspec
 
-#on circle ci - head is ambiguous for reasons that i don't grok
-#we haven't made the new tag and we can't if we are going to annotate
-head=$(git rev-parse HEAD)
-
-issue_prefix='^#'
-echo "Remember! You need to start your commit messages with #{issue_prefix}x, where x is the issue number your commit resolves."
-
-if [[ ${current_version} == nil ]];
-then
-  log_rev_range=${head}
-else
-  log_rev_range="v${current_version}..${head}"
-fi
-
-export issues=""$(git log ${log_rev_range} --oneline | awk '{print $2}' | grep "${issue_prefix}" | uniq)
-
-# if [ $tagged_commit = 0 ]; then
-#   git tag -a "v${GEM_VERSION}" -m "${GEM_VERSION}" -m "Issues with commits, not necessarily closed: ${issues}"
-#   git push --tags
-# fi
-
-# # gemspec respects GEM_VERSION envvar
+# # publish rubygem to rubygems.org, https://rubygems.org/gems/cfn-nag
 # gem build cfn-nag.gemspec
-# gem push cfn-nag-${GEM_VERSION}.gem
+# gem push cfn-nag-${new_version}.gem
 #
 # # publish docker image to DockerHub, https://hub.docker.com/r/stelligent/cfn_nag
-# docker build -t $docker_org/cfn_nag:${GEM_VERSION} .
+# docker build -t $docker_org/cfn_nag:${new_version} .
 # set +x
 # echo $docker_password | docker login -u $docker_user --password-stdin
 # set -x
-# docker tag $docker_org/cfn_nag:${GEM_VERSION} $docker_org/cfn_nag:latest
-# docker push $docker_org/cfn_nag:${GEM_VERSION}
+# docker tag $docker_org/cfn_nag:${new_version} $docker_org/cfn_nag:latest
+# docker push $docker_org/cfn_nag:${new_version}
 # docker push $docker_org/cfn_nag:latest
 
-echo "::set-output name=cfn_nag_version::${GEM_VERSION}"
-echo "::set-output name=gem_exec_path::$(gem environment | grep EXECUTABLE.DIRECTORY | sed 's/.*: //g')"
+echo "::set-output name=cfn_nag_version::${new_version}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,28 +2,28 @@
 set -o pipefail
 export minor_version="0.5"
 
-# set +x
-# if [[ -z ${rubygems_api_key} ]];
-# then
-#   echo rubygems_api_key must be set in the environment
-#   exit 1
-# fi
-# if [[ -z ${docker_user} ]];
-# then
-#   echo docker_user must be set in the environment
-#   exit 1
-# fi
-# if [[ -z ${docker_password} ]];
-# then
-#   echo docker_password must be set in the environment
-#   exit 1
-# fi
-# if [[ -z ${docker_org} ]];
-# then
-#   echo $docker_org must be set in the environment
-#   exit 1
-# fi
-# set -x
+set +x
+if [[ -z ${rubygems_api_key} ]];
+then
+  echo rubygems_api_key must be set in the environment
+  exit 1
+fi
+if [[ -z ${docker_user} ]];
+then
+  echo docker_user must be set in the environment
+  exit 1
+fi
+if [[ -z ${docker_password} ]];
+then
+  echo docker_password must be set in the environment
+  exit 1
+fi
+if [[ -z ${docker_org} ]];
+then
+  echo $docker_org must be set in the environment
+  exit 1
+fi
+set -x
 
 git config --global user.email "build@build.com"
 git config --global user.name "build"
@@ -47,17 +47,17 @@ fi
 
 sed -i.bak "s/0\.0\.0/${new_version}/g" cfn-nag.gemspec
 
-# # publish rubygem to rubygems.org, https://rubygems.org/gems/cfn-nag
-# gem build cfn-nag.gemspec
-# gem push cfn-nag-${new_version}.gem
-#
-# # publish docker image to DockerHub, https://hub.docker.com/r/stelligent/cfn_nag
-# docker build -t $docker_org/cfn_nag:${new_version} .
-# set +x
-# echo $docker_password | docker login -u $docker_user --password-stdin
-# set -x
-# docker tag $docker_org/cfn_nag:${new_version} $docker_org/cfn_nag:latest
-# docker push $docker_org/cfn_nag:${new_version}
-# docker push $docker_org/cfn_nag:latest
+# publish rubygem to rubygems.org, https://rubygems.org/gems/cfn-nag
+gem build cfn-nag.gemspec
+gem push cfn-nag-${new_version}.gem
+
+# publish docker image to DockerHub, https://hub.docker.com/r/stelligent/cfn_nag
+docker build -t $docker_org/cfn_nag:${new_version} .
+set +x
+echo $docker_password | docker login -u $docker_user --password-stdin
+set -x
+docker tag $docker_org/cfn_nag:${new_version} $docker_org/cfn_nag:latest
+docker push $docker_org/cfn_nag:${new_version}
+docker push $docker_org/cfn_nag:latest
 
 echo "::set-output name=cfn_nag_version::${new_version}"


### PR DESCRIPTION
Closes #191 

### Description

In order to provide more visibility into changes between releases, this PR adds a GitHub release to each merge to master containing the changelog since the last release.  I utilized the existing [release-drafter GitHub Action](https://github.com/marketplace/actions/release-drafter) to create pretty changelogs in each release based on labels of the PRs (see examples below).  This GitHub Action allowed me to remove all the tagging-related code from [publish.sh](scripts/publish.sh).

#### Changes

1. Added [release-drafter GitHub Action](https://github.com/marketplace/actions/release-drafter) to create GitHub releases with pretty changelogs.
2. Added cfn_nag_version output in publish.sh for use when creating GitHub release.
3. Removed git tagging related code from publish.sh.
4. Removed unneeded `setup-ruby` step from Release job.
5. Updated `curl`-based steps in workflow to use the `docker_org` environment variable.
6. Linted README.md.

### Testing

**Note**: I was unable to regression test pushing to rubygems.org and DockerHub since those are public facing.

1. After quite a bit of testing, I was able to get the workflow and GH Action to properly create releases and have them increment based on the version passed from publish.sh.

#### Before

<img width="381" alt="image" src="https://user-images.githubusercontent.com/4969682/75996667-31333400-5ecc-11ea-9e32-856351f8fe3e.png">

#### After

<img width="967" alt="image" src="https://user-images.githubusercontent.com/4969682/75996284-a81bfd00-5ecb-11ea-9c10-561ced67dfc3.png">

2. All rubocop and rspec tests passed successfully.