### PR TITLE
#58 GameLift custom rule to warn on open EC2 ingress port ranges

### DIFF
--- a/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class GameLiftFleetInboundPortRangeRule < BaseRule
+  def rule_text
+    'GameLift fleet EC2InboundPermissions found with port range instead of just a single port'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W58'
+  end
+
+  def audit_impl(cfn_model)
+    violating_gamelift_fleets = cfn_model.resources_by_type('AWS::GameLift::Fleet').select do |gamelift_fleet|
+      violating_permissions = gamelift_fleet.eC2InboundPermissions.select do |permission|
+        # subnet_mask = permission['IpRange'].split('/').length > 1 ? permission['IpRange'].split('/')[1].to_i : 32
+        # permission['FromPort'] != permission['ToPort'] || subnet_mask < 24
+        permission['FromPort'] != permission['ToPort']
+      end
+
+      !violating_permissions.empty?
+    end
+
+    violating_gamelift_fleets.map(&:logical_resource_id)
+  end
+end

--- a/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
@@ -19,8 +19,6 @@ class GameLiftFleetInboundPortRangeRule < BaseRule
   def audit_impl(cfn_model)
     violating_gamelift_fleets = cfn_model.resources_by_type('AWS::GameLift::Fleet').select do |gamelift_fleet|
       violating_permissions = gamelift_fleet.eC2InboundPermissions.select do |permission|
-        # subnet_mask = permission['IpRange'].split('/').length > 1 ? permission['IpRange'].split('/')[1].to_i : 32
-        # permission['FromPort'] != permission['ToPort'] || subnet_mask < 24
         permission['FromPort'] != permission['ToPort']
       end
 

--- a/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
@@ -19,7 +19,8 @@ class GameLiftFleetInboundPortRangeRule < BaseRule
   def audit_impl(cfn_model)
     violating_gamelift_fleets = cfn_model.resources_by_type('AWS::GameLift::Fleet').select do |gamelift_fleet|
       violating_permissions = gamelift_fleet.eC2InboundPermissions.select do |permission|
-        permission['FromPort'] != permission['ToPort']
+        # Cast to strings incase template provided mixed types
+        permission['FromPort'].to_s != permission['ToPort'].to_s
       end
 
       !violating_permissions.empty?

--- a/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
+++ b/lib/cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule.rb
@@ -13,7 +13,7 @@ class GameLiftFleetInboundPortRangeRule < BaseRule
   end
 
   def rule_id
-    'W58'
+    'W65'
   end
 
   def audit_impl(cfn_model)

--- a/spec/custom_rules/GameLiftFleetInboundPortRangeRule_spec.rb
+++ b/spec/custom_rules/GameLiftFleetInboundPortRangeRule_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/GameLiftFleetInboundPortRangeRule'
+
+describe GameLiftFleetInboundPortRangeRule do
+  context 'GameLift fleet with IpPermissions open to port range' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/gamelift/fleet_open_to_port_range.json')
+
+      actual_logical_resource_ids = GameLiftFleetInboundPortRangeRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[InsecureGameLiftFleet]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'GameLift fleet open to only individual ports' do
+    it 'does not return logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/gamelift/fleet_open_to_individual_ports.json')
+
+      actual_logical_resource_ids = GameLiftFleetInboundPortRangeRule.new.audit_impl cfn_model
+
+      expect(actual_logical_resource_ids).to eq []
+    end
+  end
+end

--- a/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
@@ -1,0 +1,31 @@
+{
+  "Resources": {
+    "SecureGameLiftFleet": {
+      "Type": "AWS::GameLift::Fleet",
+      "Properties": {
+        "EC2InboundPermissions": [
+          {
+            "FromPort": 22,
+            "ToPort": 22,
+            "IpRange": "10.1.0.0/24",
+            "Protocol": "TCP"
+          },
+          {
+            "FromPort": 1122,
+            "ToPort": 1122,
+            "IpRange": "10.1.0.0/24",
+            "Protocol": "TCP"
+          },
+          {
+            "FromPort": 10623,
+            "ToPort": 10623,
+            "IpRange": "10.1.0.0/24",
+            "Protocol": "TCP"
+          }
+        ],
+        "EC2InstanceType": "t2.micro",
+        "Name": "InsecureGameLiftFleet"
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
@@ -1,4 +1,16 @@
 {
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Description": "Create a GameLift Fleet with individual ports open.",
+	"Parameters": {
+		"Owner": {
+			"Type": "String",
+			"Description": "Owner of these resources."
+		},
+		"Project": {
+			"Type": "String",
+			"Description": "For what these resources were created."
+		}
+	},
   "Resources": {
     "SecureGameLiftFleet": {
       "Type": "AWS::GameLift::Fleet",
@@ -24,7 +36,30 @@
           }
         ],
         "EC2InstanceType": "t2.micro",
-        "Name": "InsecureGameLiftFleet"
+				"Name": "SecureGameLiftFleet",
+				"RuntimeConfiguration": {
+					"ServerProcesses": [
+						{
+						  "ConcurrentExecutions": 2,
+							"LaunchPath": "/local/game/rt_servers.js"
+						}
+					]
+				},
+				"ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
+			}
+		},
+		"RealTimeScript": {
+			"Type": "AWS::GameLift::Script",
+			"Properties": {
+				"StorageLocation": {
+					"Bucket": {
+						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
+					},
+					"Key": "rt_servers.zip",
+					"RoleArn": {
+						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
+					}
+				}
       }
     }
   }

--- a/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
@@ -23,7 +23,7 @@
             "Protocol": "TCP"
           },
           {
-            "FromPort": 1122,
+            "FromPort": "1122",
             "ToPort": 1122,
             "IpRange": "10.1.0.0/24",
             "Protocol": "TCP"

--- a/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_individual_ports.json
@@ -1,16 +1,16 @@
 {
-	"AWSTemplateFormatVersion": "2010-09-09",
-	"Description": "Create a GameLift Fleet with individual ports open.",
-	"Parameters": {
-		"Owner": {
-			"Type": "String",
-			"Description": "Owner of these resources."
-		},
-		"Project": {
-			"Type": "String",
-			"Description": "For what these resources were created."
-		}
-	},
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a GameLift Fleet with individual ports open.",
+  "Parameters": {
+    "Owner": {
+      "Type": "String",
+      "Description": "Owner of these resources."
+    },
+    "Project": {
+      "Type": "String",
+      "Description": "For what these resources were created."
+    }
+  },
   "Resources": {
     "SecureGameLiftFleet": {
       "Type": "AWS::GameLift::Fleet",
@@ -36,30 +36,30 @@
           }
         ],
         "EC2InstanceType": "t2.micro",
-				"Name": "SecureGameLiftFleet",
-				"RuntimeConfiguration": {
-					"ServerProcesses": [
-						{
-						  "ConcurrentExecutions": 2,
-							"LaunchPath": "/local/game/rt_servers.js"
-						}
-					]
-				},
-				"ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
-			}
-		},
-		"RealTimeScript": {
-			"Type": "AWS::GameLift::Script",
-			"Properties": {
-				"StorageLocation": {
-					"Bucket": {
-						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
-					},
-					"Key": "rt_servers.zip",
-					"RoleArn": {
-						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
-					}
-				}
+        "Name": "SecureGameLiftFleet",
+        "RuntimeConfiguration": {
+          "ServerProcesses": [
+            {
+              "ConcurrentExecutions": 2,
+              "LaunchPath": "/local/game/rt_servers.js"
+            }
+          ]
+        },
+        "ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
+      }
+    },
+    "RealTimeScript": {
+      "Type": "AWS::GameLift::Script",
+      "Properties": {
+        "StorageLocation": {
+          "Bucket": {
+            "Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
+          },
+          "Key": "rt_servers.zip",
+          "RoleArn": {
+            "Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
+          }
+        }
       }
     }
   }

--- a/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
@@ -17,7 +17,7 @@
       "Properties": {
         "EC2InboundPermissions": [
           {
-            "FromPort": 5758,
+            "FromPort": "5758",
             "ToPort": 60000,
             "IpRange": "10.1.0.0/24",
             "Protocol": "TCP"

--- a/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
@@ -1,16 +1,16 @@
 {
-	"AWSTemplateFormatVersion": "2010-09-09",
-	"Description": "Create a GameLift Fleet with a port range open.",
-	"Parameters": {
-		"Owner": {
-			"Type": "String",
-			"Description": "Owner of these resources."
-		},
-		"Project": {
-			"Type": "String",
-			"Description": "For what these resources were created."
-		}
-	},
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a GameLift Fleet with a port range open.",
+  "Parameters": {
+    "Owner": {
+      "Type": "String",
+      "Description": "Owner of these resources."
+    },
+    "Project": {
+      "Type": "String",
+      "Description": "For what these resources were created."
+    }
+  },
   "Resources": {
     "InsecureGameLiftFleet": {
       "Type": "AWS::GameLift::Fleet",
@@ -31,30 +31,30 @@
         ],
         "EC2InstanceType": "t2.micro",
         "Name": "InsecureGameLiftFleet",
-				"RuntimeConfiguration": {
-					"ServerProcesses": [
-						{
-						  "ConcurrentExecutions": 2,
-							"LaunchPath": "/local/game/rt_servers.js"
-						}
-					]
-				},
-				"ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
+        "RuntimeConfiguration": {
+          "ServerProcesses": [
+            {
+              "ConcurrentExecutions": 2,
+              "LaunchPath": "/local/game/rt_servers.js"
+            }
+          ]
+        },
+        "ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
       }
     },
-		"RealTimeScript": {
-			"Type": "AWS::GameLift::Script",
-			"Properties": {
-				"StorageLocation": {
-					"Bucket": {
-						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
-					},
-					"Key": "rt_servers.zip",
-					"RoleArn": {
-						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
-					}
-				}
-			}
-		}
+    "RealTimeScript": {
+      "Type": "AWS::GameLift::Script",
+      "Properties": {
+        "StorageLocation": {
+          "Bucket": {
+            "Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
+          },
+          "Key": "rt_servers.zip",
+          "RoleArn": {
+            "Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
+          }
+        }
+      }
+    }
   }
 }

--- a/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
@@ -1,0 +1,25 @@
+{
+  "Resources": {
+    "InsecureGameLiftFleet": {
+      "Type": "AWS::GameLift::Fleet",
+      "Properties": {
+        "EC2InboundPermissions": [
+          {
+            "FromPort": 1,
+            "ToPort": 60000,
+            "IpRange": "10.1.0.0/24",
+            "Protocol": "TCP"
+          },
+          {
+            "FromPort": 10666,
+            "ToPort": 10666,
+            "IpRange": "0.0.0.0/0",
+            "Protocol": "TCP"
+          }
+        ],
+        "EC2InstanceType": "t2.micro",
+        "Name": "InsecureGameLiftFleet"
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
+++ b/spec/test_templates/json/gamelift/fleet_open_to_port_range.json
@@ -1,11 +1,23 @@
 {
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Description": "Create a GameLift Fleet with a port range open.",
+	"Parameters": {
+		"Owner": {
+			"Type": "String",
+			"Description": "Owner of these resources."
+		},
+		"Project": {
+			"Type": "String",
+			"Description": "For what these resources were created."
+		}
+	},
   "Resources": {
     "InsecureGameLiftFleet": {
       "Type": "AWS::GameLift::Fleet",
       "Properties": {
         "EC2InboundPermissions": [
           {
-            "FromPort": 1,
+            "FromPort": 5758,
             "ToPort": 60000,
             "IpRange": "10.1.0.0/24",
             "Protocol": "TCP"
@@ -18,8 +30,31 @@
           }
         ],
         "EC2InstanceType": "t2.micro",
-        "Name": "InsecureGameLiftFleet"
+        "Name": "InsecureGameLiftFleet",
+				"RuntimeConfiguration": {
+					"ServerProcesses": [
+						{
+						  "ConcurrentExecutions": 2,
+							"LaunchPath": "/local/game/rt_servers.js"
+						}
+					]
+				},
+				"ScriptId": {"Fn::GetAtt": ["RealTimeScript", "Id"]}
       }
-    }
+    },
+		"RealTimeScript": {
+			"Type": "AWS::GameLift::Script",
+			"Properties": {
+				"StorageLocation": {
+					"Bucket": {
+						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSourceCodeBucketName"}
+					},
+					"Key": "rt_servers.zip",
+					"RoleArn": {
+						"Fn::ImportValue": {"Fn::Sub": "${Owner}-${Project}-GameLiftSupportRoleArn"}
+					}
+				}
+			}
+		}
   }
 }

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
@@ -1,7 +1,20 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
+Description: Create a GameLift Fleet with individual ports open.
+
+Parameters:
+  Owner:
+    Type: String
+    Description: Owner of these resources.
+    # Default: pshelby
+  Project:
+    Type: String
+    Description: For what these resources were created.
+    # Default: gamelift-testing
 
 Resources:
+  # Instructions to SSH to GameLift fleet servers
+  # https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-remote-access.html
   SecureGameLiftFleet:
     Type: AWS::GameLift::Fleet
     Properties:
@@ -19,4 +32,19 @@ Resources:
           Protocol: TCP
           ToPort: 10623
       EC2InstanceType: t2.micro
-      Name: InsecureGameLiftFleet
+      Name: SecureGameLiftFleet
+      RuntimeConfiguration:
+        ServerProcesses:
+          - ConcurrentExecutions: 2
+            LaunchPath: /local/game/rt_servers.js
+      ScriptId: !GetAtt RealTimeScript.Id
+
+  RealTimeScript:
+    Type: AWS::GameLift::Script
+    Properties:
+      StorageLocation:
+        Bucket:
+          Fn::ImportValue: !Sub ${Owner}-${Project}-GameLiftSourceCodeBucketName
+        Key: rt_servers.zip
+        RoleArn:
+          Fn::ImportValue: !Sub ${Owner}-${Project}-GameLiftSupportRoleArn

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
@@ -23,7 +23,7 @@ Resources:
           IpRange: 10.1.0.0/24
           Protocol: TCP
           ToPort: 22
-        - FromPort: 1122
+        - FromPort: '1122'
           IpRange: 10.1.0.0/24
           Protocol: TCP
           ToPort: 1122

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_individual_ports.yml
@@ -1,0 +1,22 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  SecureGameLiftFleet:
+    Type: AWS::GameLift::Fleet
+    Properties:
+      EC2InboundPermissions:
+        - FromPort: 22
+          IpRange: 10.1.0.0/24
+          Protocol: TCP
+          ToPort: 22
+        - FromPort: 1122
+          IpRange: 10.1.0.0/24
+          Protocol: TCP
+          ToPort: 1122
+        - FromPort: 10623
+          IpRange: 10.1.0.0/24
+          Protocol: TCP
+          ToPort: 10623
+      EC2InstanceType: t2.micro
+      Name: InsecureGameLiftFleet

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
@@ -26,7 +26,7 @@ Resources:
         #   - Port range (4081-60000) cannot contain restricted port 5757.
         #     (Service: AmazonGameLift; Status Code: 400; Error Code: InvalidRequestException;
         #     Request ID: 782ac772-dfe1-4fb3-8f4e-16a7e7b25b91)
-        - FromPort: 5758
+        - FromPort: '5758'
           IpRange: 10.1.0.0/24
           Protocol: TCP
           ToPort: 60000

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
@@ -13,6 +13,8 @@ Parameters:
     # Default: gamelift-testing
 
 Resources:
+  # Instructions to SSH to GameLift fleet servers
+  # https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-remote-access.html
   InsecureGameLiftFleet:
     Type: AWS::GameLift::Fleet
     Properties:

--- a/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
+++ b/spec/test_templates/yaml/gamelift/fleet_open_to_port_range.yml
@@ -1,0 +1,51 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Create a GameLift Fleet with a port range open.
+
+Parameters:
+  Owner:
+    Type: String
+    Description: Owner of these resources.
+    # Default: pshelby
+  Project:
+    Type: String
+    Description: For what these resources were created.
+    # Default: gamelift-testing
+
+Resources:
+  InsecureGameLiftFleet:
+    Type: AWS::GameLift::Fleet
+    Properties:
+      EC2InboundPermissions:
+        # Errors encountered while converging the stack:
+        #   - Port range (1-60000) cannot contain restricted port 4080.
+        #     (Service: AmazonGameLift; Status Code: 400; Error Code: InvalidRequestException;
+        #     Request ID: f99f8ef6-0be8-4f77-b670-238b571d3b6e)
+        #   - Port range (4081-60000) cannot contain restricted port 5757.
+        #     (Service: AmazonGameLift; Status Code: 400; Error Code: InvalidRequestException;
+        #     Request ID: 782ac772-dfe1-4fb3-8f4e-16a7e7b25b91)
+        - FromPort: 5758
+          IpRange: 10.1.0.0/24
+          Protocol: TCP
+          ToPort: 60000
+        - FromPort: 10666
+          IpRange: 0.0.0.0/0
+          Protocol: TCP
+          ToPort: 10666
+      EC2InstanceType: t2.micro
+      Name: InsecureGameLiftFleet
+      RuntimeConfiguration:
+        ServerProcesses:
+          - ConcurrentExecutions: 2
+            LaunchPath: /local/game/rt_servers.js
+      ScriptId: !GetAtt RealTimeScript.Id
+
+  RealTimeScript:
+    Type: AWS::GameLift::Script
+    Properties:
+      StorageLocation:
+        Bucket:
+          Fn::ImportValue: !Sub ${Owner}-${Project}-GameLiftSourceCodeBucketName
+        Key: rt_servers.zip
+        RoleArn:
+          Fn::ImportValue: !Sub ${Owner}-${Project}-GameLiftSupportRoleArn

--- a/spec/test_templates/yaml/gamelift/support_resources.yml
+++ b/spec/test_templates/yaml/gamelift/support_resources.yml
@@ -1,0 +1,102 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Setup IAM role and S3 bucket for GameLift testing.
+
+Parameters:
+  Owner:
+    Type: String
+    Description: Owner of these resources.
+    # Default: pshelby
+  Project:
+    Type: String
+    Description: For what these resources were created.
+    # Default: gamelift-testing
+
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      # BucketEncryption:
+      #   ServerSideEncryptionConfiguration:
+      #     - ServerSideEncryptionByDefault:
+      #         SSEAlgorithm: AES256
+      BucketName: !Sub ${Owner}-${Project}
+      # PublicAccessBlockConfiguration:
+      #   BlockPublicAcls: true
+      #   BlockPublicPolicy: true
+      #   IgnorePublicAcls: true
+      #   RestrictPublicBuckets: true
+
+  # S3BucketPolicy:
+  #   Type: AWS::S3::BucketPolicy
+  #   Properties:
+  #     Bucket: !Ref S3Bucket
+  #     PolicyDocument:
+  #       Version: 2012-10-17
+  #       Id: GameLiftPolicy
+  #       Statement:
+  #         - Sid: GameLiftBucketAccess
+  #           Effect: Allow
+  #           Principal:
+  #             Service: gamelift.amazonaws.com
+  #           Action:
+  #             - s3:ListBucket
+  #           Resource:
+  #             - !GetAtt S3Bucket.Arn
+  #         - Sid: GameLiftObjectAccess
+  #           Effect: Allow
+  #           Principal:
+  #             Service: gamelift.amazonaws.com
+  #           Action:
+  #             - s3:GetObject
+  #           Resource:
+  #             - !Sub ${S3Bucket.Arn}/*
+
+  IamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - gamelift.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              # - Sid: BucketRead
+              #   Effect: Allow
+              #   Action:
+              #     - s3:ListBucket
+              #   Resource:
+              #     - !GetAtt S3Bucket.Arn
+              # - Sid: ObjectRead
+              #   Effect: Allow
+              #   Action:
+              #     - s3:GetObject
+              #   Resource:
+              #     - !Sub ${S3Bucket.Arn}/*
+              - Sid: FullS3Access
+                Effect: Allow
+                Action:
+                  - s3:*
+                Resource:
+                  - !GetAtt S3Bucket.Arn
+                  - !Sub ${S3Bucket.Arn}/*
+
+Outputs:
+  GameLiftSourceCodeBucketName:
+    Description: Name of the S3 bucket for GameLift source code.
+    Value: !Ref S3Bucket
+    Export:
+      Name: !Sub ${Owner}-${Project}-GameLiftSourceCodeBucketName
+  GameLiftSupportRoleArn:
+    Description: ARN of the IAM Role for GameLift to access the source code S3 bucket.
+    Value: !GetAtt IamRole.Arn
+    Export:
+      Name: !Sub ${Owner}-${Project}-GameLiftSupportRoleArn

--- a/spec/test_templates/yaml/gamelift/support_resources.yml
+++ b/spec/test_templates/yaml/gamelift/support_resources.yml
@@ -16,41 +16,41 @@ Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      # BucketEncryption:
-      #   ServerSideEncryptionConfiguration:
-      #     - ServerSideEncryptionByDefault:
-      #         SSEAlgorithm: AES256
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       BucketName: !Sub ${Owner}-${Project}
-      # PublicAccessBlockConfiguration:
-      #   BlockPublicAcls: true
-      #   BlockPublicPolicy: true
-      #   IgnorePublicAcls: true
-      #   RestrictPublicBuckets: true
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
-  # S3BucketPolicy:
-  #   Type: AWS::S3::BucketPolicy
-  #   Properties:
-  #     Bucket: !Ref S3Bucket
-  #     PolicyDocument:
-  #       Version: 2012-10-17
-  #       Id: GameLiftPolicy
-  #       Statement:
-  #         - Sid: GameLiftBucketAccess
-  #           Effect: Allow
-  #           Principal:
-  #             Service: gamelift.amazonaws.com
-  #           Action:
-  #             - s3:ListBucket
-  #           Resource:
-  #             - !GetAtt S3Bucket.Arn
-  #         - Sid: GameLiftObjectAccess
-  #           Effect: Allow
-  #           Principal:
-  #             Service: gamelift.amazonaws.com
-  #           Action:
-  #             - s3:GetObject
-  #           Resource:
-  #             - !Sub ${S3Bucket.Arn}/*
+  S3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Id: GameLiftPolicy
+        Statement:
+          - Sid: GameLiftBucketAccess
+            Effect: Allow
+            Principal:
+              Service: gamelift.amazonaws.com
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !GetAtt S3Bucket.Arn
+          - Sid: GameLiftObjectAccess
+            Effect: Allow
+            Principal:
+              Service: gamelift.amazonaws.com
+            Action:
+              - s3:GetObject
+            Resource:
+              - !Sub ${S3Bucket.Arn}/*
 
   IamRole:
     Type: AWS::IAM::Role
@@ -69,18 +69,6 @@ Resources:
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              # - Sid: BucketRead
-              #   Effect: Allow
-              #   Action:
-              #     - s3:ListBucket
-              #   Resource:
-              #     - !GetAtt S3Bucket.Arn
-              # - Sid: ObjectRead
-              #   Effect: Allow
-              #   Action:
-              #     - s3:GetObject
-              #   Resource:
-              #     - !Sub ${S3Bucket.Arn}/*
               - Sid: FullS3Access
                 Effect: Allow
                 Action:

--- a/spec/test_templates/yaml/sam/globals.yml
+++ b/spec/test_templates/yaml/sam/globals.yml
@@ -24,3 +24,11 @@ Resources:
       Tracing: Active
       Tags:
         warmup: True
+  NewFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: !Sub "${Site}-Function"
+      Handler: "com.test.Function::handleRequest"
+      Tracing: Active
+      Tags:
+        warmup: True

--- a/spec/test_templates/yaml/sam/globals.yml
+++ b/spec/test_templates/yaml/sam/globals.yml
@@ -24,11 +24,3 @@ Resources:
       Tracing: Active
       Tags:
         warmup: True
-  NewFunction:
-    Type: 'AWS::Serverless::Function'
-    Properties:
-      FunctionName: !Sub "${Site}-Function"
-      Handler: "com.test.Function::handleRequest"
-      Tracing: Active
-      Tags:
-        warmup: True


### PR DESCRIPTION
Closes #58 

### Description

This PR creates a custom rule to warn users if they've defined a port range in the `EC2InboundPermissions` property of `AWS::GameLift::Fleet` resources.  For more detailed description of the rule and examples of it in action, see [this post](https://github.com/stelligent/cfn_nag/issues/58#issuecomment-586318894) on the linked issue.

### Testing

1. Created a new rspec test for different port range scenarios.
2. All rubocop and rspec tests passed.