### PR TITLE
Fix Omissions For W58

### DIFF
--- a/lib/cfn-nag/custom_rules/LambdaFunctionCloudWatchLogsRule.rb
+++ b/lib/cfn-nag/custom_rules/LambdaFunctionCloudWatchLogsRule.rb
@@ -32,7 +32,12 @@ class LambdaFunctionCloudWatchLogsRule < BaseRule
 
   def managed_policies_include_cw_logs_access?(managed_policies)
     !(managed_policies & ['arn:aws:iam::aws:policy/CloudWatchLogsFullAccess',
-                          'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole']
+                          'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+                          'arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole',
+                          'arn:aws:iam::aws:policy/AWSLambdaExecute',
+                          'arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole',
+                          'arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole',
+                          'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole']
      ).empty?
   end
 

--- a/spec/custom_rules/LambdaFunctionCloudWatchLogsRule_spec.rb
+++ b/spec/custom_rules/LambdaFunctionCloudWatchLogsRule_spec.rb
@@ -55,6 +55,42 @@ describe LambdaFunctionCloudWatchLogsRule do
       end
     end
 
+    context 'when function\'s role contains AWSLambdaExecute managed policy' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_lambda_execute_managed_policy.json')
+        actual_logical_resource_ids = LambdaFunctionCloudWatchLogsRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+
+    context 'when function\'s role contains AWSLambdaKinesisExecutionRole managed policy' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_lambda_kinesis_managed_policy.json')
+        actual_logical_resource_ids = LambdaFunctionCloudWatchLogsRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+
+    context 'when function\'s role contains AWSLambdaSQSQueueExecutionRole managed policy' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_lambda_sqs_managed_policy.json')
+        actual_logical_resource_ids = LambdaFunctionCloudWatchLogsRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+
+    context 'when function\'s role contains AWSLambdaVPCAccessExecutionRole managed policy' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_lambda_vpc_managed_policy.json')
+        actual_logical_resource_ids = LambdaFunctionCloudWatchLogsRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+
     context 'when function\'s role contains managed policy without CloudWatch Logs access' do
       it 'returns an offending logical resource id' do
         cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_other_managed_policies.json')

--- a/spec/custom_rules/LambdaFunctionCloudWatchLogsRule_spec.rb
+++ b/spec/custom_rules/LambdaFunctionCloudWatchLogsRule_spec.rb
@@ -46,6 +46,15 @@ describe LambdaFunctionCloudWatchLogsRule do
       end
     end
 
+    context 'when function\'s role contains AWSLambdaDynamoDBExecutionRole managed policy' do
+      it 'does not return an offending logical resource id' do
+        cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_lambda_dynamodb_managed_policy.json')
+        actual_logical_resource_ids = LambdaFunctionCloudWatchLogsRule.new.audit_impl cfn_model
+
+        expect(actual_logical_resource_ids).to eq []
+      end
+    end
+
     context 'when function\'s role contains managed policy without CloudWatch Logs access' do
       it 'returns an offending logical resource id' do
         cfn_model = CfnParser.new.parse read_test_template('json/lambda_function/lambda_with_other_managed_policies.json')

--- a/spec/test_templates/json/lambda_function/lambda_with_lambda_dynamodb_managed_policy.json
+++ b/spec/test_templates/json/lambda_function/lambda_with_lambda_dynamodb_managed_policy.json
@@ -1,0 +1,80 @@
+{
+  "Resources": {
+    "FunctionWithLambdaDynamoDBManagedPolicyRoleByRef": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Ref": "RoleWithLambdaDynamoDBManagedPolicy"},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "FunctionWithLambdaDynamoDBManagedPolicyRoleByFnGetAtt": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["RoleWithLambdaDynamoDBManagedPolicy", "Arn"]},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "RoleWithLambdaDynamoDBManagedPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "lambda.amazonaws.com"},
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole"],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["specific:ObscureAction"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/lambda_function/lambda_with_lambda_execute_managed_policy.json
+++ b/spec/test_templates/json/lambda_function/lambda_with_lambda_execute_managed_policy.json
@@ -1,0 +1,80 @@
+{
+  "Resources": {
+    "FunctionWithLambdaExecuteManagedPolicyRoleByRef": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Ref": "RoleWithLambdaExecuteManagedPolicy"},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "FunctionWithLambdaExecuteManagedPolicyRoleByFnGetAtt": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["RoleWithLambdaExecuteManagedPolicy", "Arn"]},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "RoleWithLambdaExecuteManagedPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "lambda.amazonaws.com"},
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AWSLambdaExecute"],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["specific:ObscureAction"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/lambda_function/lambda_with_lambda_kinesis_managed_policy.json
+++ b/spec/test_templates/json/lambda_function/lambda_with_lambda_kinesis_managed_policy.json
@@ -1,0 +1,80 @@
+{
+  "Resources": {
+    "FunctionWithLambdaKinesisManagedPolicyRoleByRef": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Ref": "RoleWithLambdaKinesisManagedPolicy"},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "FunctionWithLambdaKinesisManagedPolicyRoleByFnGetAtt": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["RoleWithLambdaKinesisManagedPolicy", "Arn"]},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "RoleWithLambdaKinesisManagedPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "lambda.amazonaws.com"},
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["specific:ObscureAction"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/lambda_function/lambda_with_lambda_sqs_managed_policy.json
+++ b/spec/test_templates/json/lambda_function/lambda_with_lambda_sqs_managed_policy.json
@@ -1,0 +1,80 @@
+{
+  "Resources": {
+    "FunctionWithLambdaSQSManagedPolicyRoleByRef": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Ref": "RoleWithLambdaSQSManagedPolicy"},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "FunctionWithLambdaSQSManagedPolicyRoleByFnGetAtt": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["RoleWithLambdaSQSManagedPolicy", "Arn"]},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "RoleWithLambdaSQSManagedPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "lambda.amazonaws.com"},
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["specific:ObscureAction"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/lambda_function/lambda_with_lambda_vpc_managed_policy.json
+++ b/spec/test_templates/json/lambda_function/lambda_with_lambda_vpc_managed_policy.json
@@ -1,0 +1,80 @@
+{
+  "Resources": {
+    "FunctionWithLambdaVPCAccessManagedPolicyRoleByRef": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Ref": "RoleWithLambdaVPCAccessManagedPolicy"},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "FunctionWithLambdaVPCAccessManagedPolicyRoleByFnGetAtt": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.handler",
+        "Role": {"Fn::GetAtt": ["RoleWithLambdaVPCAccessManagedPolicy", "Arn"]},
+        "Code": {
+          "ZipFile": {
+            "Fn::Join": [
+              "",
+              [
+                "var response = require('cfn-response');",
+                "exports.handler = function(event, context) {",
+                "var responseData = {Value: event.ResourceProperties.List};",
+                "responseData.Value.push(event.ResourceProperties.AppendedItem);",
+                "response.send(event, context, response.SUCCESS, responseData);}"
+              ]
+            ]
+          }
+        },
+        "Runtime": "nodejs6.10"
+      }
+    },
+    "RoleWithLambdaVPCAccessManagedPolicy": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {"Service": "lambda.amazonaws.com"},
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": ["specific:ObscureAction"],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Issue**
The existing conditions for W58 - _Lambda functions require permission to write CloudWatch Logs_ omits some alternative managed policies which may be utilised by the function that do provide CloudWatch Logs permissions. 

This leads to a situation where false positive warnings are generated, where a function is flagged as not having write access to CloudWatch Logs when it actually does.

**Fix**
A number of additional managed policies designed for usage with Lambda that do provide CloudWatch Logs write permissions have been added to reduce false positives.