### PR TITLE
Locking release-drafter version to fix GH workflow

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -66,7 +66,7 @@ jobs:
           docker_password: ${{secrets.docker_password}}
       - name: Create release with changelog
         id: gh_release
-        uses: release-drafter/release-drafter@master
+        uses: release-drafter/release-drafter@f677696
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Fixes failing GitHub Workflow

### Description

Lock release-master version down to a SHA hash that contains the publish functionality to avoid issues with the latest master branch.

### Testing

Tested on my personal fork with success.
<img width="754" alt="image" src="https://user-images.githubusercontent.com/4969682/76974532-b294b880-6907-11ea-8bca-7264788a032c.png">