### PR TITLE
#378 Created missing_property_base_rule and applied to SageMaker EndpointConfig/NotebookInstance

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -66,7 +66,7 @@ jobs:
           docker_password: ${{secrets.docker_password}}
       - name: Create release with changelog
         id: gh_release
-        uses: release-drafter/release-drafter@master
+        uses: release-drafter/release-drafter@f677696
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/lib/cfn-nag/custom_rules/SageMakerEndpointConfigKmsKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SageMakerEndpointConfigKmsKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'missing_property_base_rule'
+
+class SageMakerEndpointConfigKmsKeyIdRule < MissingPropertyBaseRule
+  def rule_text
+    'SageMaker EndpointConfig must have a KmsKeyId property set.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W1200'
+  end
+
+  def resource_type
+    'AWS::SageMaker::EndpointConfig'
+  end
+
+  def property_name
+    :kmsKeyId
+  end
+end

--- a/lib/cfn-nag/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'missing_property_base_rule'
+
+class SageMakerNotebookInstanceKmsKeyIdRule < MissingPropertyBaseRule
+  def rule_text
+    'SageMaker NotebookInstance must have a KmsKeyId property set.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W1201'
+  end
+
+  def resource_type
+    'AWS::SageMaker::NotebookInstance'
+  end
+
+  def property_name
+    :kmsKeyId
+  end
+end

--- a/lib/cfn-nag/custom_rules/missing_property_base_rule.rb
+++ b/lib/cfn-nag/custom_rules/missing_property_base_rule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/enforce_reference_parameter'
+require 'cfn-nag/util/enforce_string_or_dynamic_reference'
+require_relative 'base'
+
+class MissingPropertyBaseRule < BaseRule
+  def resource_type
+    raise 'must implement in subclass'
+  end
+
+  def property_name
+    raise 'must implement in subclass'
+  end
+
+  def audit_impl(cfn_model)
+    resources = cfn_model.resources_by_type(resource_type)
+
+    violating_resources = resources.select do |resource|
+      resource.send(property_name).nil?
+    end
+
+    violating_resources.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rule_spec_helper.rb
+++ b/spec/custom_rule_spec_helper.rb
@@ -11,22 +11,7 @@ def file_path_prefix(resource_type, test_template_type)
   path_prefix
 end
 
-# Name of the password tests to run, matching the test teplates file names
-# States whether the test should be a pass or fail
-def password_rule_test_sets
-  {
-    'not set': 'pass',
-    'parameter with NoEcho': 'pass',
-    'parameter with NoEcho and Default value': 'fail',
-    'parameter as a literal in plaintext': 'fail',
-    'as a literal in plaintext': 'fail',
-    'from Secrets Manager': 'pass',
-    'from Secure Systems Manager': 'pass',
-    'from Systems Manager': 'fail'
-  }
-end
-
-# Returns a string based on the value result of the password_rule_test_sets
+# Returns a string based on the value result of the rule test sets
 def context_return_value(desired_test_result)
   raise 'desired_test_result value must be either "pass" or "fail"' unless
     %w[pass fail].include?(desired_test_result)
@@ -39,49 +24,29 @@ def context_return_value(desired_test_result)
 end
 
 # Creates the string name for the rule
-def rule_name(resource_type, password_property, sub_property_name)
-  if sub_property_name.nil?
-    _nil_sub_property_name_rule_name(resource_type, password_property)
-  else
-    _not_nil_sub_property_name_rule_name(
-      resource_type, password_property, sub_property_name
-    )
-  end
-end
+def rule_name(resource_type, property_name, sub_property_name)
+  sub_property_value = sub_property_name.nil? ? '' : sub_property_name
 
-# Creates the logic for the rule name if sub_property_name is nil
-def _nil_sub_property_name_rule_name(resource_type, password_property)
   [
     resource_type.sub('AWS', '').gsub('::', ''),
-    password_property,
-    'Rule'
-  ].join
-end
-
-# Creates the logic for the rule name if sub_property_name is present
-def _not_nil_sub_property_name_rule_name(
-  resource_type, password_property, sub_property_name
-)
-  [
-    resource_type.sub('AWS', '').gsub('::', ''),
-    password_property,
-    sub_property_name,
+    property_name,
+    sub_property_value,
     'Rule'
   ].join
 end
 
 # Creates full file path string
 def file_path(
-  resource_type, test_template_type, password_property, sub_property_name,
+  resource_type, test_template_type, property_name, sub_property_name,
   test_description
 )
   if sub_property_name.nil?
     _nil_sub_property_name_file_path(
-      resource_type, test_template_type, password_property, test_description
+      resource_type, test_template_type, property_name, test_description
     )
   else
     _not_nil_sub_property_name_file_path(
-      resource_type, test_template_type, password_property,
+      resource_type, test_template_type, property_name,
       sub_property_name, test_description
     )
   end
@@ -89,11 +54,11 @@ end
 
 # Creates the logic for the file path if sub_property_name is nil
 def _nil_sub_property_name_file_path(
-  resource_type, test_template_type, password_property, test_description
+  resource_type, test_template_type, property_name, test_description
 )
   [
     file_path_prefix(resource_type, test_template_type),
-    password_property.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
+    property_name.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
     '_',
     test_description.to_s.gsub(' ', '_').downcase,
     '.',
@@ -103,12 +68,12 @@ end
 
 # Creates the logic for the file path if sub_property_name is present
 def _not_nil_sub_property_name_file_path(
-  resource_type, test_template_type, password_property,
+  resource_type, test_template_type, property_name,
   sub_property_name, test_description
 )
   [
     file_path_prefix(resource_type, test_template_type),
-    password_property.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
+    property_name.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
     '_',
     sub_property_name.gsub(/(?<=[a-z])(?=[A-Z])/, ' ').gsub(' ', '_').downcase,
     '_',
@@ -118,7 +83,7 @@ def _not_nil_sub_property_name_file_path(
   ].join
 end
 
-# Returns an array based on the value result of the password_rule_test_sets
+# Returns an array based on the value result of the rule test sets
 def expected_logical_resource_ids(desired_test_result, resource_type)
   raise 'desired_test_result value must be either "pass" or "fail"' unless
     %w[pass fail].include?(desired_test_result)
@@ -132,13 +97,13 @@ end
 
 # Run the spec test
 def run_test(
-  resource_type, password_property, sub_property_name, test_template_type,
+  resource_type, property_name, sub_property_name, test_template_type,
   test_description, desired_test_result
 )
   cfn_model =
     CfnParser.new.parse read_test_template(
       file_path(
-        resource_type, test_template_type, password_property,
+        resource_type, test_template_type, property_name,
         sub_property_name, test_description
       )
     )

--- a/spec/custom_rule_test_sets.rb
+++ b/spec/custom_rule_test_sets.rb
@@ -1,0 +1,23 @@
+# Name of the password tests to run, matching the test teplates file names
+# States whether the test should be a pass or fail
+def password_rule_test_sets
+  {
+    'not set': 'pass',
+    'parameter with NoEcho': 'pass',
+    'parameter with NoEcho and Default value': 'fail',
+    'parameter as a literal in plaintext': 'fail',
+    'as a literal in plaintext': 'fail',
+    'from Secrets Manager': 'pass',
+    'from Secure Systems Manager': 'pass',
+    'from Systems Manager': 'fail'
+  }
+end
+
+# Name of the missing property tests to run, matching the test teplates file names
+# States whether the test should be a pass or fail
+def missing_property_rule_test_sets
+  {
+    'not set': 'fail',
+    'set': 'pass'
+  }
+end

--- a/spec/custom_rules/AmazonMQBrokerEncryptOptionsRule_spec.rb
+++ b/spec/custom_rules/AmazonMQBrokerEncryptOptionsRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 require 'cfn-nag/custom_rules/AmazonMQBrokerEncryptionOptionsRule'
 

--- a/spec/custom_rules/AmazonMQBrokerUsersPasswordRule_spec.rb
+++ b/spec/custom_rules/AmazonMQBrokerUsersPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::AmazonMQ::Broker'

--- a/spec/custom_rules/AmplifyAppAccessTokenRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppAccessTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Amplify::App'

--- a/spec/custom_rules/AmplifyAppBasicAuthConfigPasswordRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppBasicAuthConfigPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Amplify::App'

--- a/spec/custom_rules/AmplifyAppOauthTokenRule_spec.rb
+++ b/spec/custom_rules/AmplifyAppOauthTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Amplify::App'

--- a/spec/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule_spec.rb
+++ b/spec/custom_rules/AmplifyBranchBasicAuthConfigPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Amplify::Branch'

--- a/spec/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule_spec.rb
+++ b/spec/custom_rules/AppStreamDirectoryConfigServiceAccountCredentialsAccountPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::AppStream::DirectoryConfig'

--- a/spec/custom_rules/CodePipelineWebhookAuthenticationConfigurationSecretTokenRule_spec.rb
+++ b/spec/custom_rules/CodePipelineWebhookAuthenticationConfigurationSecretTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::CodePipeline::Webhook'

--- a/spec/custom_rules/DMSEndpointMongoDbSettingsPasswordRule_spec.rb
+++ b/spec/custom_rules/DMSEndpointMongoDbSettingsPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::DMS::Endpoint'

--- a/spec/custom_rules/DocDBDBClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/DocDBDBClusterMasterUserPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::DocDB::DBCluster'

--- a/spec/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesADDomainJoinPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::EMR::Cluster'

--- a/spec/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesCrossRealmTrustPrincipalPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::EMR::Cluster'

--- a/spec/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule_spec.rb
+++ b/spec/custom_rules/EMRClusterKerberosAttributesKdcAdminPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::EMR::Cluster'

--- a/spec/custom_rules/ElastiCacheReplicationGroupAuthTokenRule_spec.rb
+++ b/spec/custom_rules/ElastiCacheReplicationGroupAuthTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::ElastiCache::ReplicationGroup'

--- a/spec/custom_rules/IAMUserLoginProfilePasswordRule_spec.rb
+++ b/spec/custom_rules/IAMUserLoginProfilePasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::IAM::User'

--- a/spec/custom_rules/KinesisFirehoseDeliveryStreamRedshiftDestinationConfigurationPasswordRule_spec.rb
+++ b/spec/custom_rules/KinesisFirehoseDeliveryStreamRedshiftDestinationConfigurationPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::KinesisFirehose::DeliveryStream'

--- a/spec/custom_rules/KinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECTokenRule_spec.rb
+++ b/spec/custom_rules/KinesisFirehoseDeliveryStreamSplunkDestinationConfigurationHECTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::KinesisFirehose::DeliveryStream'

--- a/spec/custom_rules/LambdaPermissionEventSourceTokenRule_spec.rb
+++ b/spec/custom_rules/LambdaPermissionEventSourceTokenRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Lambda::Permission'

--- a/spec/custom_rules/OpsWorksAppAppSourcePasswordRule_spec.rb
+++ b/spec/custom_rules/OpsWorksAppAppSourcePasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::OpsWorks::App'

--- a/spec/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/OpsWorksAppSslConfigurationPrivateKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::OpsWorks::App'

--- a/spec/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule_spec.rb
+++ b/spec/custom_rules/OpsWorksStackCustomCookbooksSourcePasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::OpsWorks::Stack'

--- a/spec/custom_rules/OpsWorksStackRdsDbInstancesDbPasswordRule_spec.rb
+++ b/spec/custom_rules/OpsWorksStackRdsDbInstancesDbPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::OpsWorks::Stack'

--- a/spec/custom_rules/PinpointAPNSChannelPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSChannelPrivateKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSChannel'

--- a/spec/custom_rules/PinpointAPNSChannelTokenKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSChannelTokenKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSChannel'

--- a/spec/custom_rules/PinpointAPNSSandboxChannelPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSSandboxChannelPrivateKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSSandboxChannel'

--- a/spec/custom_rules/PinpointAPNSSandboxChannelTokenKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSSandboxChannelTokenKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSSandboxChannel'

--- a/spec/custom_rules/PinpointAPNSVoipChannelPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSVoipChannelPrivateKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSVoipChannel'

--- a/spec/custom_rules/PinpointAPNSVoipChannelTokenKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSVoipChannelTokenKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSVoipChannel'

--- a/spec/custom_rules/PinpointAPNSVoipSandboxChannelPrivateKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSVoipSandboxChannelPrivateKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSVoipSandboxChannel'

--- a/spec/custom_rules/PinpointAPNSVoipSandboxChannelTokenKeyRule_spec.rb
+++ b/spec/custom_rules/PinpointAPNSVoipSandboxChannelTokenKeyRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Pinpoint::APNSVoipSandboxChannel'

--- a/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBClusterMasterUserPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::RDS::DBCluster'

--- a/spec/custom_rules/RDSDBInstanceMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RDSDBInstanceMasterUserPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::RDS::DBInstance'

--- a/spec/custom_rules/RDSDBInstanceMasterUsernameRule_spec.rb
+++ b/spec/custom_rules/RDSDBInstanceMasterUsernameRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::RDS::DBInstance'

--- a/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
+++ b/spec/custom_rules/RedshiftClusterMasterUserPasswordRule_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 require 'cfn-model'
 
 resource_type = 'AWS::Redshift::Cluster'

--- a/spec/custom_rules/SageMakerEndpointConfigKmsKeyIdRule_spec.rb
+++ b/spec/custom_rules/SageMakerEndpointConfigKmsKeyIdRule_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
+require 'cfn-model'
+
+resource_type = 'AWS::SageMaker::EndpointConfig'
+property_name = 'KmsKeyId'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, property_name, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, property_name, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the missing_property_rule_test_sets hash
+  missing_property_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{property_name} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, property_name, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule_spec.rb
+++ b/spec/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
+require 'cfn-model'
+
+resource_type = 'AWS::SageMaker::NotebookInstance'
+property_name = 'KmsKeyId'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, property_name, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, property_name, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the missing_property_rule_test_sets hash
+  missing_property_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{property_name} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, property_name, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/missing_property_base_rule_spec.rb
+++ b/spec/custom_rules/missing_property_base_rule_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/missing_property_base_rule'
+
+describe MissingPropertyBaseRule do
+  describe '#audit' do
+    before(:all) do
+      @base_rule = MissingPropertyBaseRule.new
+      @base_rule.instance_eval do
+        def rule_id
+          'F3334'
+        end
+
+        def rule_type
+          Violation::FAILING_VIOLATION
+        end
+
+        def rule_text
+          'This is an epic fail!'
+        end
+
+        def resource_type
+          'AWS::Redshift::Cluster'
+        end
+
+        def property_name
+          :masterUserPassword
+        end
+      end
+    end
+
+    before(:all) do
+      @failing_violation = Violation.new(id: 'F3334',
+                                         type: Violation::FAILING_VIOLATION,
+                                         message: 'This is an epic fail!',
+                                         logical_resource_ids: %w[RedshiftCluster])
+    end
+
+    it 'raises an error when properties are not set' do
+      expect do
+        MissingPropertyBaseRule.new.audit_impl nil
+      end.to raise_error 'must implement in subclass'
+    end
+
+    it 'returns violation when property is not set' do
+      base_rule = @base_rule
+
+      expect(base_rule).to \
+        receive(:property_name).and_return(:masterUserPassword)
+      expect(base_rule).to \
+        receive(:resource_type).and_return('AWS::Redshift::Cluster')
+
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_not_set.yaml'
+      )
+
+      expected_violation = @failing_violation
+
+      expect(base_rule.audit(cfn_model)).to eq expected_violation
+    end
+
+    it 'returns no violation when property is set' do
+      base_rule = @base_rule
+
+      expect(base_rule).to \
+        receive(:property_name).and_return(:masterUserPassword)
+      expect(base_rule).to \
+        receive(:resource_type).and_return('AWS::Redshift::Cluster')
+
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/redshift_cluster/' \
+        'redshift_cluster_master_user_password_parameter_with_noecho.yaml'
+      )
+
+      expect(base_rule.audit(cfn_model)).to be nil
+    end
+  end
+end

--- a/spec/password_rule_spec_helper_spec.rb
+++ b/spec/password_rule_spec_helper_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
-require 'password_rule_spec_helper'
+require 'custom_rule_spec_helper'
+require 'custom_rule_test_sets'
 
-describe 'password_rule_spec_helper' do
+describe 'custom_rule_spec_helper' do
   before(:all) do
     @resource_type = 'AWS::Foo::Bar'
     @password_property = 'Baz'

--- a/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_not_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_not_set.yaml
@@ -1,0 +1,14 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker EndpointConfig without the requisite KmsKeyId property.
+
+Resources:
+  SageMakerEndpointConfig:
+    Type: AWS::SageMaker::EndpointConfig
+    Properties:
+      ProductionVariants:
+        - ModelName: Model1
+          VariantName: Variant1
+          InitialInstanceCount: 1
+          InstanceType: ml.t2.medium
+          InitialVariantWeight: 1.0

--- a/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: Define a SageMaker EndpointConfig without the requisite KmsKeyId property.
+Description: Define a SageMaker EndpointConfig with the requisite KmsKeyId property.
 
 Resources:
   SageMakerEndpointConfig:

--- a/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
@@ -1,0 +1,15 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker EndpointConfig without the requisite KmsKeyId property.
+
+Resources:
+  SageMakerEndpointConfig:
+    Type: AWS::SageMaker::EndpointConfig
+    Properties:
+      KmsKeyId: alias/SuperSecureKey
+      ProductionVariants:
+        - ModelName: Model1
+          VariantName: Variant1
+          InitialInstanceCount: 1
+          InstanceType: ml.t2.medium
+          InitialVariantWeight: 1.0

--- a/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_not_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_not_set.yaml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker NotebookInstance without the requisite KmsKeyId property.
+
+Resources:
+  SageMakerNotebookInstance:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      InstanceType: ml.t2.large
+      RoleArn: arn:aws:iam::012345678910:role/MLUserRole

--- a/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_set.yaml
@@ -1,0 +1,11 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker NotebookInstance with the requisite KmsKeyId property.
+
+Resources:
+  SageMakerNotebookInstance:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      InstanceType: ml.t2.large
+      KmsKeyId: alias/SuperSecureKey
+      RoleArn: arn:aws:iam::012345678910:role/MLUserRole


### PR DESCRIPTION
Closes #378 

### Description

In order to detect missing properties, I created a base rule which will be flexible enough to detect any missing property for any type of resource.  I built the rule on top of and reworked the existing `password_rule_spec_helper` logic so it is more generic and can be extended as well.

1. Reworked `password_rule_spec_helper` to `custom_rule_spec_helper` so it can be used in more generic cases.
2. Added a missing_property_base_rule to detect missing properties in given resources.
3. Created custom rules to warn on missing KmsKeyId properties for both SageMaker EndpointConfig and NotebookInstance resources.
4. Moved "rule test sets" to their own file for ease of reading and extension.
5. Wrote appropriate tests.

### Testing

1. Created test templates for missing and existing properties.
2. All rubocop and rspec tests pass.