### PR TITLE
#378 Created custom rules from boolean_base_rule and applied to SageMaker EndpointConfig/NotebookInstance

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -66,7 +66,7 @@ jobs:
           docker_password: ${{secrets.docker_password}}
       - name: Create release with changelog
         id: gh_release
-        uses: release-drafter/release-drafter@master
+        uses: release-drafter/release-drafter@f677696
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/lib/cfn-nag/custom_rules/SageMakerEndpointConfigKmsKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SageMakerEndpointConfigKmsKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'boolean_base_rule'
+
+class SageMakerEndpointConfigKmsKeyIdRule < BooleanBaseRule
+  def rule_text
+    'SageMaker EndpointConfig should have a KmsKeyId property set.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W1200'
+  end
+
+  def resource_type
+    'AWS::SageMaker::EndpointConfig'
+  end
+
+  def boolean_property
+    :kmsKeyId
+  end
+end

--- a/lib/cfn-nag/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'boolean_base_rule'
+
+class SageMakerNotebookInstanceKmsKeyIdRule < BooleanBaseRule
+  def rule_text
+    'SageMaker NotebookInstance should have a KmsKeyId property set.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W1201'
+  end
+
+  def resource_type
+    'AWS::SageMaker::NotebookInstance'
+  end
+
+  def boolean_property
+    :kmsKeyId
+  end
+end

--- a/spec/custom_rules/SageMakerEndpointConfigKmsKeyIdRule_spec.rb
+++ b/spec/custom_rules/SageMakerEndpointConfigKmsKeyIdRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::SageMaker::EndpointConfig'
+property_name = 'KmsKeyId'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, property_name, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, property_name, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the missing_property_rule_test_sets hash
+  boolean_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{property_name} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, property_name, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule_spec.rb
+++ b/spec/custom_rules/SageMakerNotebookInstanceKmsKeyIdRule_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+
+resource_type = 'AWS::SageMaker::NotebookInstance'
+property_name = 'KmsKeyId'
+sub_property_name = nil
+test_template_type = 'yaml'
+
+require "cfn-nag/custom_rules/#{rule_name(resource_type, property_name, sub_property_name)}"
+
+describe Object.const_get(rule_name(resource_type, property_name, sub_property_name)), :rule do
+  # Creates dynamic set of contexts based on the missing_property_rule_test_sets hash
+  boolean_rule_test_sets.each do |test_description, desired_test_result|
+    context "#{resource_type} #{property_name} #{sub_property_name} #{test_description}" do
+      it context_return_value(desired_test_result) do
+        run_test(resource_type, property_name, sub_property_name,
+                 test_template_type, test_description, desired_test_result)
+      end
+    end
+  end
+end

--- a/spec/password_rule_spec_helper.rb
+++ b/spec/password_rule_spec_helper.rb
@@ -26,6 +26,15 @@ def password_rule_test_sets
   }
 end
 
+# Name of the boolean tests to run, matching the test teplates file names
+# States whether the test should be a pass or fail
+def boolean_rule_test_sets
+  {
+    'not set': 'fail',
+    'set': 'pass'
+  }
+end
+
 # Returns a string based on the value result of the password_rule_test_sets
 def context_return_value(desired_test_result)
   raise 'desired_test_result value must be either "pass" or "fail"' unless

--- a/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_not_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_not_set.yaml
@@ -1,0 +1,14 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker EndpointConfig without the requisite KmsKeyId property.
+
+Resources:
+  SageMakerEndpointConfig:
+    Type: AWS::SageMaker::EndpointConfig
+    Properties:
+      ProductionVariants:
+        - ModelName: Model1
+          VariantName: Variant1
+          InitialInstanceCount: 1
+          InstanceType: ml.t2.medium
+          InitialVariantWeight: 1.0

--- a/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_endpointconfig/sagemaker_endpointconfig_kms_key_id_set.yaml
@@ -1,0 +1,15 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker EndpointConfig with the requisite KmsKeyId property.
+
+Resources:
+  SageMakerEndpointConfig:
+    Type: AWS::SageMaker::EndpointConfig
+    Properties:
+      KmsKeyId: alias/SuperSecureKey
+      ProductionVariants:
+        - ModelName: Model1
+          VariantName: Variant1
+          InitialInstanceCount: 1
+          InstanceType: ml.t2.medium
+          InitialVariantWeight: 1.0

--- a/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_not_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_not_set.yaml
@@ -1,0 +1,10 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker NotebookInstance without the requisite KmsKeyId property.
+
+Resources:
+  SageMakerNotebookInstance:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      InstanceType: ml.t2.large
+      RoleArn: arn:aws:iam::012345678910:role/MLUserRole

--- a/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/sagemaker_notebookinstance/sagemaker_notebookinstance_kms_key_id_set.yaml
@@ -1,0 +1,11 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Define a SageMaker NotebookInstance with the requisite KmsKeyId property.
+
+Resources:
+  SageMakerNotebookInstance:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      InstanceType: ml.t2.large
+      KmsKeyId: alias/SuperSecureKey
+      RoleArn: arn:aws:iam::012345678910:role/MLUserRole


### PR DESCRIPTION
Closes #378 
Reworked from PR #417 

### Description

In order to detect missing KmsKeyId properties, I created custom rules from the boolean base rule which is flexible enough to detect any missing property for any type of resource.

1. Created custom rules from `boolean_base_rule` to warn on missing KmsKeyId properties for both SageMaker EndpointConfig and NotebookInstance resources.
2. Added "boolean rule test sets" to extend the password_rule test framework.
5. Wrote appropriate tests.

### Testing

1. Created test templates for missing and existing properties.
2. All rubocop and rspec tests pass.