### PR TITLE
https://github.com/stelligent/cfn_nag/issues/384 Cloudfront TLS 1.2 rule

### DIFF
--- a/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
+++ b/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class CloudfrontMinimumProtocolVersionRule < BaseRule
+  def rule_text
+    'Cloudfront should use minimum protocol version TLS 1.2'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W70'
+  end
+
+  def audit_impl(cfn_model)
+    violating_distributions = cfn_model.resources_by_type('AWS::CloudFront::Distribution')
+                                       .select do |distribution|
+      distribution.distributionConfig['ViewerCertificate'].nil? || distribution.distributionConfig['ViewerCertificate']['MinimumProtocolVersion'].nil? || distribution.distributionConfig['ViewerCertificate']['MinimumProtocolVersion'] != 'TLSv1.2_2018' || !distribution.distributionConfig['ViewerCertificate']['CloudFrontDefaultCertificate'].nil? || distribution.distributionConfig['ViewerCertificate']['CloudFrontDefaultCertificate']
+    end
+
+    violating_distributions.map(&:logical_resource_id)
+  end
+end

--- a/spec/cfn_nag_integration/cfn_nag_cloudfront_distribution_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_cloudfront_distribution_spec.rb
@@ -25,6 +25,12 @@ describe CfnNag do
                 line_numbers: [46]
               ),
               Violation.new(
+                id: 'W70', type: Violation::WARNING,
+                message: 'Cloudfront should use minimum protocol version TLS 1.2',
+                logical_resource_ids: ["rDistribution1", "rDistribution2"],
+                line_numbers: [4,46]
+              ),
+              Violation.new(
                 id: 'W51', type: Violation::WARNING,
                 message: 'S3 bucket should likely have a bucket policy',
                 logical_resource_ids: %w[S3Bucket],

--- a/spec/custom_rules/CloudfrontMinimumProtocolVersionRule_spec.rb
+++ b/spec/custom_rules/CloudfrontMinimumProtocolVersionRule_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule'
+
+describe CloudfrontMinimumProtocolVersionRule do
+  context 'distribution without tls config' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/cloudfront_distribution/cloudfront_with_no_tls_config.json')
+
+      actual_logical_resource_ids = CloudfrontMinimumProtocolVersionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[ApiGatewayWithNoTLSConfg]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'distribution without bad tls or default tls config' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/cloudfront_distribution/cloudfront_with_tls_10.json')
+
+      actual_logical_resource_ids = CloudfrontMinimumProtocolVersionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = ["ApiGatewayWithSSLv3", "ApiGatewayWithTLS10", "ApiGatewayWithTLS11", "ApiGatewayWithTLS12016", "ApiGatewayWithDefaultTLS"]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'distribution with minimum tls 1.2 and not override by CloudFrontDefaultCertificate Usage' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template('json/cloudfront_distribution/cloudfront_with_tls_12.json')
+
+      actual_logical_resource_ids = CloudfrontMinimumProtocolVersionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = ["ApiGatewayWithTls12OverridebyCloudFrontDefaultCertificateUsage"]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+end

--- a/spec/test_templates/json/cloudfront_distribution/cloudfront_with_no_tls_config.json
+++ b/spec/test_templates/json/cloudfront_distribution/cloudfront_with_no_tls_config.json
@@ -1,0 +1,18 @@
+{
+	"Resources": {
+		"ApiGatewayWithNoTLSConfg": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"Origins": [
+						{
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+					}
+				}
+			}
+		}
+	}
+}

--- a/spec/test_templates/json/cloudfront_distribution/cloudfront_with_tls_10.json
+++ b/spec/test_templates/json/cloudfront_distribution/cloudfront_with_tls_10.json
@@ -1,0 +1,99 @@
+{
+	"Resources": {
+		"ApiGatewayWithSSLv3": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "SSLv3"
+					},
+					"Origins": [
+						{
+
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+
+					}
+				}
+			}
+		},
+		"ApiGatewayWithTLS10": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "TLSv1"
+					},
+					"Origins": [
+						{
+
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+
+					}
+				}
+			}
+		},
+		"ApiGatewayWithTLS11": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "TLSv1.1"
+					},
+					"Origins": [
+						{
+
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+
+					}
+				}
+			}
+		},
+		"ApiGatewayWithTLS12016": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "TLSv1_2016"
+					},
+					"Origins": [
+						{
+
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+
+					}
+				}
+			}
+		},
+		"ApiGatewayWithDefaultTLS": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+
+					},
+					"Origins": [
+						{
+
+						}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {
+
+					}
+				}
+			}
+		}
+	}
+}

--- a/spec/test_templates/json/cloudfront_distribution/cloudfront_with_tls_12.json
+++ b/spec/test_templates/json/cloudfront_distribution/cloudfront_with_tls_12.json
@@ -1,0 +1,35 @@
+{
+	"Resources": {
+		"ApiGatewayWithTls12": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "TLSv1.2_2018"
+					},
+					"Origins": [
+						{}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {}
+				}
+			}
+		},
+		"ApiGatewayWithTls12OverridebyCloudFrontDefaultCertificateUsage": {
+			"Type": "AWS::CloudFront::Distribution",
+			"Properties": {
+				"DistributionConfig": {
+					"ViewerCertificate": {
+						"MinimumProtocolVersion": "TLSv1.2_2018",
+						"CloudFrontDefaultCertificate" : true
+					},
+					"Origins": [
+						{}
+					],
+					"Enabled": "false",
+					"DefaultCacheBehavior": {}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When using CloudFrontDefaultCertificate  (you set CloudFrontDefaultCertificate to true), CloudFront automatically sets the security policy to TLSv1 regardless of the value that you set here.)

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-viewercertificate.html