### PR TITLE
[standardize-casecmp] Standardize case compare for older ruby support

### DIFF
--- a/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2AccessLoggingRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticLoadBalancerV2AccessLoggingRule.rb
@@ -29,7 +29,7 @@ class ElasticLoadBalancerV2AccessLoggingRule < BaseRule
 
   def access_logging_is_false?(load_balancer)
     false_access_log_attribute = load_balancer.loadBalancerAttributes.find do |load_balancer_attribute|
-      load_balancer_attribute['Key'] ==  'access_logs.s3.enabled' && load_balancer_attribute['Value'].casecmp?('false')
+      load_balancer_attribute['Key'] ==  'access_logs.s3.enabled' && load_balancer_attribute['Value'].casecmp('false').zero?
     end
     false_access_log_attribute
   end

--- a/lib/cfn-nag/custom_rules/ElasticsearchDomainEncryptionAtRestOptionsRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticsearchDomainEncryptionAtRestOptionsRule.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cfn-nag/util/truthy'
 require 'cfn-nag/violation'
 require_relative 'base'
 
@@ -18,15 +19,9 @@ class ElasticsearchDomainEncryptionAtRestOptionsRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_domains = cfn_model.resources_by_type('AWS::Elasticsearch::Domain').select do |domain|
-      domain.encryptionAtRestOptions.nil? || encryption_not_enabled?(domain.encryptionAtRestOptions)
+      domain.encryptionAtRestOptions.nil? || not_truthy?(domain.encryptionAtRestOptions['Enabled'])
     end
 
     violating_domains.map(&:logical_resource_id)
-  end
-
-  private
-
-  def encryption_not_enabled?(encryption_at_rest_options)
-    encryption_at_rest_options['Enabled'].nil? || encryption_at_rest_options['Enabled'].to_s.casecmp('false').zero?
   end
 end

--- a/lib/cfn-nag/custom_rules/ElasticsearchDomainEncryptionAtRestOptionsRule.rb
+++ b/lib/cfn-nag/custom_rules/ElasticsearchDomainEncryptionAtRestOptionsRule.rb
@@ -27,6 +27,6 @@ class ElasticsearchDomainEncryptionAtRestOptionsRule < BaseRule
   private
 
   def encryption_not_enabled?(encryption_at_rest_options)
-    encryption_at_rest_options['Enabled'].nil? || encryption_at_rest_options['Enabled'].to_s.casecmp?('false')
+    encryption_at_rest_options['Enabled'].nil? || encryption_at_rest_options['Enabled'].to_s.casecmp('false').zero?
   end
 end


### PR DESCRIPTION
- Standardize our casecmp usage across custom_rules to older-ruby supported format.