### PR TITLE
Update accessLogSettings key for API GatewayV2

### DIFF
--- a/lib/cfn-nag/custom_rules/ApiGatewayV2AccessLoggingRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewayV2AccessLoggingRule.rb
@@ -18,7 +18,7 @@ class ApiGatewayV2AccessLoggingRule < BaseRule
 
   def audit_impl(cfn_model)
     violating_deployments = cfn_model.resources_by_type('AWS::ApiGatewayV2::Stage').select do |deployment|
-      deployment.accessLogSetting.nil?
+      deployment.accessLogSettings.nil?
     end
 
     violating_deployments.map(&:logical_resource_id)

--- a/spec/test_templates/json/apigateway_accesslogging_v2/apigateway_with_access_logging.json
+++ b/spec/test_templates/json/apigateway_accesslogging_v2/apigateway_with_access_logging.json
@@ -3,7 +3,7 @@
 		"ApiGatewayWithAccessLogging": {
 			"Type": "AWS::ApiGatewayV2::Stage",
 			"Properties": {
-					"AccessLogSetting": {
+					"AccessLogSettings": {
 						"DestinationArn": "arn",
 						"Format": "format"
 					}


### PR DESCRIPTION
A bug existed in cfn_nag where it would flag valid templates that had accessLogSettings defined as not being valid. It appears that they changed the key from v1 to v2. 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html

I was unable to run the tests locally as I can't install docker in wsl 😊 , there may need to be more changes than this but this was the obvious ones to me. 