### PR TITLE
Allow running cfn_nag as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: cfn_nag
+    name: cfn_nag
+    entry: cfn_nag
+    language: ruby
+    files: \.(json|template|yaml|yml)$


### PR DESCRIPTION
- This will make it easy for users to run cfn_nag before committing any file to git.
- See https://pre-commit.com/
