### PR TITLE
Update Network ACL overlapping port rule (Fixes #487, #483)

### DIFF
--- a/lib/cfn-nag/custom_rules/EC2NetworkAclEntryOverlappingPortsRule.rb
+++ b/lib/cfn-nag/custom_rules/EC2NetworkAclEntryOverlappingPortsRule.rb
@@ -43,7 +43,7 @@ class EC2NetworkAclEntryOverlappingPortsRule < BaseRule
   end
 
   def valid_ports?(entry)
-    valid_port_number?(entry.portRange['From']) && valid_port_number?(entry.portRange['To'])
+    !entry.portRange.nil? && valid_port_number?(entry.portRange['From']) && valid_port_number?(entry.portRange['To'])
   end
 
   def valid_port_number?(port)

--- a/spec/cfn_nag_integration/cfn_nag_ec2_network_acl_entry_spec.rb
+++ b/spec/cfn_nag_integration/cfn_nag_ec2_network_acl_entry_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'cfn-nag/cfn_nag_config'
+require 'cfn-nag/cfn_nag'
+require 'cfn-nag/cfn_nag_logging'
+
+describe CfnNag do
+  before(:all) do
+    CfnNagLogging.configure_logging(debug: false)
+    @cfn_nag = CfnNag.new(config: CfnNagConfig.new)
+  end
+
+  context 'when nacl entry rule has metadata ignore' do
+    it 'does not warn' do
+      template_name = 'yaml/ec2_networkaclentry/metadata_overlapping_ports.yml'
+
+      expected_aggregate_results = [
+        {
+          filename: test_template_path(template_name),
+          file_results: {
+            failure_count: 0,
+            violations: []
+          }
+        }
+      ]
+
+      actual_aggregate_results = @cfn_nag.audit_aggregate_across_files input_path: test_template_path(template_name)
+      expect(actual_aggregate_results).to eq expected_aggregate_results
+    end
+  end
+end

--- a/spec/test_templates/yaml/ec2_networkaclentry/ec2_networkaclentry_port_overlap_non_tcp_udp.yml
+++ b/spec/test_templates/yaml/ec2_networkaclentry/ec2_networkaclentry_port_overlap_non_tcp_udp.yml
@@ -17,7 +17,7 @@ Resources:
       CidrBlock: "10.0.0.0/16"
       Egress: false
       NetworkAclId: !Ref 'myNetworkAcl'
-      Protocol: '-1'
+      Protocol: -1
       RuleAction: allow
       RuleNumber: 1000
   myNetworkAclEntry2:
@@ -26,6 +26,6 @@ Resources:
       CidrBlock: "10.0.0.0/16"
       Egress: false
       NetworkAclId: !Ref 'myNetworkAcl'
-      Protocol: '-1'
+      Protocol: -1
       RuleAction: allow
       RuleNumber: 2000

--- a/spec/test_templates/yaml/ec2_networkaclentry/ec2_networkaclentry_port_overlaps.yml
+++ b/spec/test_templates/yaml/ec2_networkaclentry/ec2_networkaclentry_port_overlaps.yml
@@ -15,48 +15,47 @@ Resources:
     Type: AWS::EC2::NetworkAclEntry
     Properties:
       NetworkAclId: !Ref myNetworkAcl
-      Protocol: "6"
+      Protocol: 6
       RuleAction: "allow"
-      RuleNumber: "100"
+      RuleNumber: 100
       CidrBlock: "10.0.0.0/16"
       Egress: false
       PortRange:
-        From: '400'
-        To: '500'
+        From: 400
+        To: 500
   myNetworkAclEntry2:
     Type: AWS::EC2::NetworkAclEntry
     Properties:
       NetworkAclId: !Ref myNetworkAcl
-      Protocol: "6"
+      Protocol: 6
       RuleAction: "deny"
-      RuleNumber: "200"
+      RuleNumber: 200
       CidrBlock: "0.0.0.0/0"
       Egress: false
       PortRange:
-        From: '450'
-        To: '475'
+        From: 450
+        To: 475
   myNetworkAclEntry3:
     Type: AWS::EC2::NetworkAclEntry
     Properties:
       NetworkAclId: !Ref myNetworkAcl
-      Protocol: "6"
+      Protocol: 6
       RuleAction: "deny"
-      RuleNumber: "300"
+      RuleNumber: 300
       CidrBlock: "0.0.0.0/0"
       Egress: false
       PortRange:
-        From: '200'
-        To: '200'
+        From: 200
+        To: 200
   myNetworkAclEntry4:
     Type: AWS::EC2::NetworkAclEntry
     Properties:
       NetworkAclId: !Ref myNetworkAcl
-      Protocol: "6"
+      Protocol: 6
       RuleAction: "deny"
-      RuleNumber: "300"
+      RuleNumber: 300
       CidrBlock: "0.0.0.0/0"
       Egress: false
       PortRange:
-        From: '300'
-        To: '400'
-  
+        From: 300
+        To: 400

--- a/spec/test_templates/yaml/ec2_networkaclentry/metadata_overlapping_ports.yml
+++ b/spec/test_templates/yaml/ec2_networkaclentry/metadata_overlapping_ports.yml
@@ -1,0 +1,37 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Test
+Parameters:
+    PublicNetworkAcl:
+      Type: String
+      Description: 'Nacl Port'
+Resources:
+  InboundHTTPPublicNetworkAclEntry:
+    Type: AWS::EC2::NetworkAclEntry
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W72
+            reason: I know what I am doing
+    Properties:
+      NetworkAclId: !Ref 'PublicNetworkAcl'
+      RuleNumber: 100
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80
+  InboundHTTPPublicNetworkAclEntry2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'PublicNetworkAcl'
+      RuleNumber: 101
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80

--- a/spec/test_templates/yaml/ec2_networkaclentry/overlapping_ports_no_nacl.yml
+++ b/spec/test_templates/yaml/ec2_networkaclentry/overlapping_ports_no_nacl.yml
@@ -1,0 +1,47 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Test
+Parameters:
+    NaclIdOne:
+      Type: String
+      Description: 'Id for first Nacl'
+    NaclIdTwo:
+      Type: String
+      Description: 'Id for first Nacl'
+Resources:
+  BadNaclEntry1:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'NaclIdOne'
+      RuleNumber: 100
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80
+  BadNaclEntry2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'NaclIdOne'
+      RuleNumber: 101
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80
+  GoodNaclEntry1:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'NaclIdTwo'
+      RuleNumber: 101
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80

--- a/spec/test_templates/yaml/ec2_networkaclentry/ref_ports.yml
+++ b/spec/test_templates/yaml/ec2_networkaclentry/ref_ports.yml
@@ -1,0 +1,45 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Test
+Parameters:
+    NaclPort:
+      Type: Number
+      Default: '80'
+      Description: 'Nacl Port'
+    VpcId:
+      Type: String
+      Description: 'VPC Id'
+Resources:
+  PublicNetworkAcl:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+      VpcId: !Ref 'VpcId'
+      Tags:
+        - Key: Application
+          Value: !Ref 'AWS::StackName'
+        - Key: Network
+          Value: Public
+  InboundHTTPPublicNetworkAclEntry:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'PublicNetworkAcl'
+      RuleNumber: 100
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: !Ref NaclPort
+        To:  !Ref NaclPort
+  InboundHTTPPublicNetworkAclEntry2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      NetworkAclId: !Ref 'PublicNetworkAcl'
+      RuleNumber: 101
+      Protocol: 6
+      RuleAction: 'allow'
+      Egress: false
+      CidrBlock: '0.0.0.0/0'
+      PortRange:
+        From: 80
+        To:  80


### PR DESCRIPTION
Fix issue with evaluating NACL entries using non-literal ports
Fix issue with evaluating NACL entries without direct NACL resource in the same template
Fix issue with metadata not ignoring warnings on NACL entries
Fix up various lint errors in yaml test templates
Refactor NACL grouping logic