### PR TITLE
Update MinimumProtocolVersion to the most recent TLSv1.2_2019

### DIFF
--- a/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
+++ b/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
@@ -32,7 +32,7 @@ class CloudfrontMinimumProtocolVersionRule < BaseRule
   end
 
   def cert_has_bad_tls_version?(viewer_certificate)
-    viewer_certificate['MinimumProtocolVersion'].nil? || viewer_certificate['MinimumProtocolVersion'] != 'TLSv1.2_2018'
+    viewer_certificate['MinimumProtocolVersion'].nil? || viewer_certificate['MinimumProtocolVersion'] != 'TLSv1.2_2019'
   end
 
   def override_tls_config?(viewer_certificate)

--- a/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
+++ b/lib/cfn-nag/custom_rules/CloudfrontMinimumProtocolVersionRule.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 
 class CloudfrontMinimumProtocolVersionRule < BaseRule
   def rule_text
-    'Cloudfront should use minimum protocol version TLS 1.2'
+    'Cloudfront should use the most advanced available TLS protocol version'
   end
 
   def rule_type


### PR DESCRIPTION
tiny fix for waring `(W70) Cloudfront should use minimum protocol version TLS 1.2`
when  
`  MinimumProtocolVersion: TLSv1.2_2019`

proof: [AWS::CloudFront::Distribution ViewerCertificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-viewercertificate.html#cfn-cloudfront-distribution-viewercertificate-minimumprotocolversion)
