### PR TITLE
#500 Added new rule for Kendra Index KmsKeyId

### DIFF
--- a/lib/cfn-nag/custom_rules/KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule.rb
+++ b/lib/cfn-nag/custom_rules/KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule < BaseRule
+  def rule_text
+    'Kendra Index ServerSideEncryptionConfiguration should specify a KmsKeyId value.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W80'
+  end
+
+  def audit_impl(cfn_model)
+    violating_indices = cfn_model.resources_by_type('AWS::Kendra::Index').select do |index|
+      index.serverSideEncryptionConfiguration.nil? ||
+        index.serverSideEncryptionConfiguration['KmsKeyId'].nil?
+    end
+
+    violating_indices.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule_spec.rb
+++ b/spec/custom_rules/KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule'
+
+describe KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule do
+  context 'Kendra Index without ServerSideConfiguration set' do
+    it 'Returns the logical resource ID of the offending KendraIndex resource' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/kendra_index/kendra_index_server_side_encryption_configuration_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[KendraIndex]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+  
+  context 'Kendra Index ServerSideConfiguration without KmsKeyId set' do
+    it 'Returns the logical resource ID of the offending KendraIndex resource' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[KendraIndex]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'Kendra Index ServerSideConfiguration with KmsKeyId set' do
+    it 'Returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        KendraIndexServerSideEncryptionConfigurationKmsKeyIdRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_not_set.yaml
+++ b/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_not_set.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  KendraIndex:
+    Type: AWS::Kendra::Index
+    Properties:
+      Edition: ENTERPRISE_EDITION
+      Name: KendraIndexWithoutKmsKeyId
+      RoleArn: arn:aws:iam::123456789012:role/KendraIndex-foobar
+      ServerSideEncryptionConfiguration:
+        FooBar: foobar

--- a/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_set.yaml
+++ b/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_kms_key_id_set.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  KendraIndex:
+    Type: AWS::Kendra::Index
+    Properties:
+      Edition: ENTERPRISE_EDITION
+      Name: KendraIndexWithKmsKeyId
+      RoleArn: arn:aws:iam::123456789012:role/KendraIndex-foobar
+      ServerSideEncryptionConfiguration:
+        KmsKeyId: alias/SuperSecureKey

--- a/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_not_set.yaml
+++ b/spec/test_templates/yaml/kendra_index/kendra_index_server_side_encryption_configuration_not_set.yaml
@@ -1,0 +1,8 @@
+---
+Resources:
+  KendraIndex:
+    Type: AWS::Kendra::Index
+    Properties:
+      Edition: ENTERPRISE_EDITION
+      Name: KendraIndexWithoutServerSideEncryptionConfiguration
+      RoleArn: arn:aws:iam::123456789012:role/KendraIndex-foobar


### PR DESCRIPTION
Closes #500 

Adds new rule to check and ensure that a `KmsKeyId` is set when creating a `AWS::Kendra::Index` resource. Also ensures that the `ServerSideEncryptionConfiguration` property is declared as that is required to specify the `KmsKeyId` sub-property.