### PR TITLE
#379 enable encryption check for DLM LifecyclePolicy CrossRegionCopy Actions

### DIFF
--- a/lib/cfn-nag/custom_rules/DLMLifecyclePolicyCrossRegionCopyEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/DLMLifecyclePolicyCrossRegionCopyEncryptionRule.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/truthy'
+require_relative 'base'
+
+class DLMLifecyclePolicyCrossRegionCopyEncryptionRule < BaseRule
+  def rule_text
+    'DLM LifecyclePolicy PolicyDetails Actions CrossRegionCopy EncryptionConfiguration should enable Encryption'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W81'
+  end
+
+  def audit_impl(cfn_model)
+    violating_policies = cfn_model.resources_by_type('AWS::DLM::LifecyclePolicy').select do |policy|
+      if policy.policyDetails['Actions'].nil?
+        false
+      else
+        violating_actions = policy.policyDetails['Actions'].select do |action|
+          violating_copies = action['CrossRegionCopy'].select do |copy|
+            !truthy?(copy['EncryptionConfiguration']['Encrypted'].to_s)
+          end
+          !violating_copies.empty?
+        end
+        !violating_actions.empty?
+      end
+    end
+
+    violating_policies.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/DLMLifecyclePolicyCrossRegionCopyEncryptionRule_spec.rb
+++ b/spec/custom_rules/DLMLifecyclePolicyCrossRegionCopyEncryptionRule_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/DLMLifecyclePolicyCrossRegionCopyEncryptionRule'
+
+describe DLMLifecyclePolicyCrossRegionCopyEncryptionRule do
+  context 'DLM LifecyclePolicy PolicyDetails Actions not used' do
+    it 'Returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_actions_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        DLMLifecyclePolicyCrossRegionCopyEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DLM LifecyclePolicy PolicyDetails Actions CrossRegionCopy EncryptionConfiguration Encrypted set to False' do
+    it 'Returns the logical resource ID of the offending DLM LifecyclePolicy resource' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_false.yaml'
+      )
+
+      actual_logical_resource_ids =
+        DLMLifecyclePolicyCrossRegionCopyEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DLMLifeCyclePolicy]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DLM LifecyclePolicy PolicyDetails Actions CrossRegionCopy EncryptionConfiguration Encrypted set to True' do
+    it 'Returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_true.yaml'
+      )
+
+      actual_logical_resource_ids =
+        DLMLifecyclePolicyCrossRegionCopyEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_actions_not_set.yaml
+++ b/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_actions_not_set.yaml
@@ -1,0 +1,27 @@
+---
+Resources:
+  DLMLifeCyclePolicy:
+    Type: AWS::DLM::LifecyclePolicy
+    Properties:
+      Description: Lifecycle Policy using CloudFormation
+      State: ENABLED
+      ExecutionRoleArn: arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole
+      PolicyDetails:
+        ResourceTypes:
+          - VOLUME
+        TargetTags:
+          - Key: costcenter
+            Value: '115'
+        Schedules:
+          - Name: Daily Snapshots
+            TagsToAdd:
+              - Key: type
+                Value: DailySnapshot
+            CreateRule:
+              Interval: 12
+              IntervalUnit: HOURS
+              Times:
+                - '13:00'
+            RetainRule:
+              Count: 1
+            CopyTags: true

--- a/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_false.yaml
+++ b/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_false.yaml
@@ -1,0 +1,15 @@
+---
+Resources:
+  DLMLifeCyclePolicy:
+    Type: AWS::DLM::LifecyclePolicy
+    Properties:
+      Description: Lifecycle Policy using CloudFormation
+      State: ENABLED
+      ExecutionRoleArn: arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole
+      PolicyDetails:
+        Actions:
+          - Name: CrossRegionCopyActionWithEncryptionDisabled
+            CrossRegionCopy:
+              - EncryptionConfiguration:
+                  Encrypted: False
+                Target: us-east-1

--- a/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_true.yaml
+++ b/spec/test_templates/yaml/dlm_lifecyclepolicy/dlm_lifecyclepolicy_cross_region_copy_encrypted_set_to_true.yaml
@@ -1,0 +1,15 @@
+---
+Resources:
+  DLMLifeCyclePolicy:
+    Type: AWS::DLM::LifecyclePolicy
+    Properties:
+      Description: Lifecycle Policy using CloudFormation
+      State: ENABLED
+      ExecutionRoleArn: arn:aws:iam::123456789012:role/AWSDataLifecycleManagerDefaultRole
+      PolicyDetails:
+        Actions:
+          - Name: CrossRegionCopyActionWithEncryptionEnabled
+            CrossRegionCopy:
+              - EncryptionConfiguration:
+                  Encrypted: True
+                Target: us-east-1


### PR DESCRIPTION
Closes #379 

Adds a warning rule the DLM LifecyclePolicy if an action is specified within the `PolicyDetails` property, otherwise ignores it. Currently the only allowed action is `CrossRegionCopy`. This rule checks to ensure that `Encrypted` is set to `True` within that `EncryptionConfiguration`.