### PR TITLE
#503 adding rule for eks cluster encryption config provider

### DIFF
--- a/lib/cfn-nag/custom_rules/EKSClusterEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/EKSClusterEncryptionRule.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require_relative 'base'
+
+class EKSClusterEncryptionRule < BaseRule
+  def rule_text
+    'EKS Cluster EncryptionConfig Provider should specify KeyArn to enable Encryption.'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W82'
+  end
+
+  def audit_impl(cfn_model)
+    violating_clusters = cfn_model.resources_by_type('AWS::EKS::Cluster').select do |cluster|
+      if cluster.encryptionConfig.nil?
+        true
+      elsif violating_configs?(cluster)
+        true
+      else
+        violating_providers?(cluster)
+      end
+    end
+
+    violating_clusters.map(&:logical_resource_id)
+  end
+
+  private
+
+  def violating_configs?(cluster)
+    violating_config = cluster.encryptionConfig.select do |config|
+      config['Provider'].nil?
+    end
+    !violating_config.empty?
+  end
+
+  def violating_providers?(cluster)
+    violating_provider = cluster.encryptionConfig.select do |config|
+      config['Provider']['KeyArn'].empty?
+    end
+    !violating_provider.empty?
+  end
+end

--- a/spec/custom_rules/EKSClusterEncryptionRuleRule_spec.rb
+++ b/spec/custom_rules/EKSClusterEncryptionRuleRule_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'password_rule_spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/EKSClusterEncryptionRule'
+
+describe EKSClusterEncryptionRule do
+  context 'EKS Cluster with no EncryptionConfig' do
+    it 'Returns the logical resource ID of the offending EKS Cluster resource' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/eks_cluster/eks_cluster_encryptionconfig_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        EKSClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[EKSCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'EKS Cluster with EncryptionConfig Provider KeyArn set' do
+    it 'Returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/eks_cluster/eks_cluster_encryptionconfig_provider_keyarn_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        EKSClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'EKS Cluster EncryptionConfig with Provider not set' do
+    it 'Returns the logical resource ID of the offending EKS Cluster resource' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/eks_cluster/eks_cluster_encryptionconfig_provider_not_set.yaml'
+      )
+
+      actual_logical_resource_ids =
+        EKSClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[EKSCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_not_set.yaml
+++ b/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_not_set.yaml
@@ -1,0 +1,15 @@
+---
+Resources:
+  EKSCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: foobar
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-foobar12
+        SubnetIds:
+          - subnet-foobar12
+          - subnet-foobar34

--- a/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_provider_keyarn_set.yaml
+++ b/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_provider_keyarn_set.yaml
@@ -1,0 +1,20 @@
+---
+Resources:
+  EKSCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: foobar
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-foobar12
+        SubnetIds:
+          - subnet-foobar12
+          - subnet-foobar34
+      EncryptionConfig:
+        - Provider:
+            KeyArn: alias/SuperSecureKey
+          Resources:
+            - Foo: bar

--- a/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_provider_not_set.yaml
+++ b/spec/test_templates/yaml/eks_cluster/eks_cluster_encryptionconfig_provider_not_set.yaml
@@ -1,0 +1,18 @@
+---
+Resources:
+  EKSCluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Name: foobar
+      Version: '1.14'
+      RoleArn: >-
+        arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonEKS-EXAMPLEBQ4PI
+      ResourcesVpcConfig:
+        SecurityGroupIds:
+          - sg-foobar12
+        SubnetIds:
+          - subnet-foobar12
+          - subnet-foobar34
+      EncryptionConfig:
+        - Resources:
+            - Foo: bar


### PR DESCRIPTION
Partial for #503 

Creates a new rule to ensure that the EKS Cluster is set up properly with an `EndpointConfig Provider` using a KMS Key. It warns if `EndpointConfig` or `EndpointConfig Provider` is missing, or if `EndpointConfig Provider` is missing the required `KeyArn` property value.