### PR TITLE
#503 encryption rule for dynamodb accelerator clusters

### DIFF
--- a/lib/cfn-nag/custom_rules/DAXClusterEncryptionRule.rb
+++ b/lib/cfn-nag/custom_rules/DAXClusterEncryptionRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/truthy'
+require_relative 'base'
+
+class DAXClusterEncryptionRule < BaseRule
+  def rule_text
+    'DynamoDB Accelerator (DAX) Cluster should have encryption enabled'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W83'
+  end
+
+  def audit_impl(cfn_model)
+    violating_clusters = cfn_model.resources_by_type('AWS::DAX::Cluster').select do |cluster|
+      cluster.sSESpecification.nil? || !truthy?(cluster.sSESpecification['SSEEnabled'].to_s)
+    end
+
+    violating_clusters.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/DAXClusterEncryptionRule_spec.rb
+++ b/spec/custom_rules/DAXClusterEncryptionRule_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/DAXClusterEncryptionRule'
+
+describe DAXClusterEncryptionRule do
+  context 'DynamoDB Accelerator Cluster without encryption' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dax_cluster/dax_cluster_with_encryption_not_set.yaml'
+      )
+
+      actual_logical_resource_ids = DAXClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DAXCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DynamoDB Accelerator Cluster with encryption enabled' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dax_cluster/dax_cluster_with_encryption_enabled.yaml'
+      )
+
+      actual_logical_resource_ids = DAXClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = []
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'DynamoDB Accelerator Cluster with encryption disabled' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/dax_cluster/dax_cluster_with_encryption_disabled.yaml'
+      )
+
+      actual_logical_resource_ids = DAXClusterEncryptionRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[DAXCluster]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_disabled.yaml
+++ b/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_disabled.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  DAXCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      NodeType: dax.r3.large
+      ReplicationFactor: 1
+      IAMRoleARN: arn:aws:iam::012345678912:role/DaxAccess
+      SSESpecification:
+        SSEEnabled: False

--- a/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_enabled.yaml
+++ b/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_enabled.yaml
@@ -1,0 +1,10 @@
+---
+Resources:
+  DAXCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      NodeType: dax.r3.large
+      ReplicationFactor: 1
+      IAMRoleARN: arn:aws:iam::012345678912:role/DaxAccess
+      SSESpecification:
+        SSEEnabled: True

--- a/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_not_set.yaml
+++ b/spec/test_templates/yaml/dax_cluster/dax_cluster_with_encryption_not_set.yaml
@@ -1,0 +1,8 @@
+---
+Resources:
+  DAXCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      NodeType: dax.r3.large
+      ReplicationFactor: 1
+      IAMRoleARN: arn:aws:iam::012345678912:role/DaxAccess


### PR DESCRIPTION
Partial for #503 

Creates a rule to ensure that encryption is enabled for DynamoDB Accelerator (DAX) Clusters