### PR TITLE
#503 rule to ensure cloudwatchlogs loggroups are encrypted

### DIFF
--- a/lib/cfn-nag/custom_rules/LogsLogGroupEncryptedRule.rb
+++ b/lib/cfn-nag/custom_rules/LogsLogGroupEncryptedRule.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'cfn-nag/violation'
+require 'cfn-nag/util/truthy'
+require_relative 'base'
+
+class LogsLogGroupEncryptedRule < BaseRule
+  def rule_text
+    'CloudWatchLogs LogGroup should specify a KMS Key Id to encrypt the log data'
+  end
+
+  def rule_type
+    Violation::WARNING
+  end
+
+  def rule_id
+    'W84'
+  end
+
+  def audit_impl(cfn_model)
+    violating_groups = cfn_model.resources_by_type('AWS::Logs::LogGroup').select do |group|
+      group.kmsKeyId.nil?
+    end
+
+    violating_groups.map(&:logical_resource_id)
+  end
+end

--- a/spec/custom_rules/LogsLogGroupEncryptedRule_spec.rb
+++ b/spec/custom_rules/LogsLogGroupEncryptedRule_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'cfn-model'
+require 'cfn-nag/custom_rules/LogsLogGroupEncryptedRule'
+
+describe LogsLogGroupEncryptedRule do
+  context 'CloudWatchLogs LogGroup without encryption' do
+    it 'returns offending logical resource id' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_without_encryption.yaml'
+      )
+
+      actual_logical_resource_ids = LogsLogGroupEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[CWLogGroup]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+
+  context 'CloudWatchLogs LogGroup with encryption' do
+    it 'returns empty list' do
+      cfn_model = CfnParser.new.parse read_test_template(
+        'yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_with_encryption.yaml'
+      )
+
+      actual_logical_resource_ids = LogsLogGroupEncryptedRule.new.audit_impl cfn_model
+      expected_logical_resource_ids = %w[]
+
+      expect(actual_logical_resource_ids).to eq expected_logical_resource_ids
+    end
+  end
+end

--- a/spec/test_templates/yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_with_encryption.yaml
+++ b/spec/test_templates/yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_with_encryption.yaml
@@ -1,0 +1,7 @@
+---
+Resources:
+  CWLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: alias/SuperSecureKey
+      RetentionInDays: 7

--- a/spec/test_templates/yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_without_encryption.yaml
+++ b/spec/test_templates/yaml/cloudwatchlogs_loggroup/cloudwatchlogs_loggroup_without_encryption.yaml
@@ -1,0 +1,6 @@
+---
+Resources:
+  CWLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 7


### PR DESCRIPTION
Partial for #503 

Creates rule to ensure that a `KmsKeyId` is used when creating a CloudWatch Logs LogGroup resource