### PR TITLE
Remove unneeded homebrew update

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -83,12 +83,3 @@ jobs:
                -H "Content-Type: application/json" \
                https://api.github.com/repos/${{ env.docker_org }}/cfn-nag-pipeline/dispatches \
                --data '{"event_type": "build_application"}'
-      - name: Trigger homebrew-tap repo workflow
-        run: |
-          curl -s \
-               -X POST \
-               -u "stelligent-releasebot:${{secrets.GITHUB_TOKEN}}" \
-               -H "Accept: application/vnd.github.v3+json" \
-               -H "Content-Type: application/json" \
-               https://api.github.com/repos/${{ env.docker_org }}/homebrew-tap/dispatches \
-               --data '{"event_type": "build_application"}'


### PR DESCRIPTION
As discussed in #267 , the gem uses `brew-gem` and the custom brew tap/formula does not need to be updated as part of the pipeline.