### PR TITLE
Set pipefail option (Fixes #582)

### DIFF
--- a/github-action/entrypoint.sh
+++ b/github-action/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -o pipefail
+
 echo "::debug::Using input path: ${INPUT_INPUT_PATH}"
 echo "::debug::Using output path: ${INPUT_OUTPUT_PATH}"
 


### PR DESCRIPTION
- To avoid the pipe swallows the exit code of the cfn_nag_scan command