### PR TITLE
Change maximum Ruby version in tests to 3.1

### DIFF
--- a/.github/workflows/tests-linting.yml
+++ b/.github/workflows/tests-linting.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false # Allows both ruby versions to run before failing
       matrix:
-        ruby: ['2.5', '3.0']
+        ruby: ['2.5', '3.1']
 
     steps:
     - uses: actions/checkout@master
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false # Allows both ruby versions to run before failing
       matrix:
-        ruby: ['2.5', '3.0']
+        ruby: ['2.5', '3.1']
 
     steps:
     # is this the same commit hash we saw in commit?


### PR DESCRIPTION
This PR updates the maximum Ruby version used in tests from '3.0' to '3.1'.