### PR TITLE
Add rule for ApiGatewayStage data trace enabled

### DIFF
--- a/lib/cfn-nag/custom_rules/ApiGatewayStageDataTraceEnabledRule.rb
+++ b/lib/cfn-nag/custom_rules/ApiGatewayStageDataTraceEnabledRule.rb
@@ -1,0 +1,32 @@
+require 'cfn-nag/violation'
+require_relative 'sub_property_with_list_truthy_value_base_rule'
+
+# Checks for truthy (boolean true) 'MethodSettings.DataTraceEnabled' property
+# Setting this value to true may unintentionally expose sensitive data in logs
+
+class ApiGatewayStageDataTraceEnabledRule < SubPropertyWithListTruthyValueBaseRule
+  def rule_text
+    'AWS::ApiGateway::Stage should set DataTraceEnabled to false.'
+  end
+
+  def rule_type
+    Violation::FAILING_VIOLATION
+  end
+
+  def rule_id
+    'CW4200'
+  end
+
+  def resource_type
+    'AWS::ApiGateway::Stage'
+  end
+
+  def sublist_property
+    :methodSettings
+  end
+
+  def sub_property_name
+    'DataTraceEnabled'
+  end
+
+end

--- a/lib/cfn-nag/custom_rules/sub_property_with_list_truthy_value_base_rule.rb
+++ b/lib/cfn-nag/custom_rules/sub_property_with_list_truthy_value_base_rule.rb
@@ -1,0 +1,52 @@
+require 'cfn-nag/violation'
+require 'cfn-nag/util/truthy'
+require_relative 'base'
+
+# Returns "violating map" of sublist properties that are
+# truthy (boolean true)
+
+class SubPropertyWithListTruthyValueBaseRule < BaseRule
+  def resource_type
+      raise 'must implement in subclass'
+  end
+
+
+  def sublist_property
+      raise 'must implement in subclass'
+  end
+
+
+  def sub_property_name; end
+
+  def audit_impl(cfn_model)
+    resources = cfn_model.resources_by_type(resource_type)
+
+    violating_resources = resources.select do |resource|
+      begin
+        truthy_subproperty_in_list(
+          cfn_model, resource, sublist_property, sub_property_name
+        )
+      rescue
+        false
+      end
+    end
+
+    violating_resources.map(&:logical_resource_id)
+  end
+
+
+  private
+
+  def truthy_subproperty_in_list(
+    cfn_model, resource, sublist_property, sub_property_name
+  )
+    property_list = resource.send(sublist_property)
+    return false unless property_list
+
+    property_list.find do |property_element|
+      sub_value = property_element[sub_property_name]
+      truthy?(property_element[sub_property_name]) || property_element[sub_property_name].nil?
+    end
+  end
+
+end


### PR DESCRIPTION
# Custom Rule: ApiGatewayStageDataTraceEnabledRule.rb

Violation occurs when ApiGatewayStage has a parameter in the parameter list MethodSettings with the sub-parameter DataTraceEnabled set to true.

Tracing API Gateway stage data may lead to sensittve data in logs.

# Custom Rule: sub_property_with_list_truthy_value_base_rule.rb

Support for resource properties that contain a list of properties. Implements raising violation when sub property parameter is not set or is set to true.