### PR TITLE
Update Dockerfile files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
+# syntax=docker/dockerfile:1
+
 FROM ruby:2.7-alpine
 
-# an explicitly blank version appears to grab latest
-# override here for a real build process
+LABEL org.opencontainers.image.authors='Stelligent'
+LABEL org.opencontainers.image.licenses='MIT'
+LABEL org.opencontainers.image.source='https://github.com/stelligent/cfn_nag'
+LABEL org.opencontainers.image.title='cfn_nag'
+LABEL org.opencontainers.image.vendor='Stelligent'
+
+# An explicitly blank version appears to grab latest.
+# Pass the required version with `--build-arg version=${YOUR_VERSION}` for a real build process.
 ARG version=''
 
 RUN gem install cfn-nag --version "$version"

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,11 +1,20 @@
+# syntax=docker/dockerfile:1
+
 FROM ruby:2.7-alpine
+
+LABEL org.opencontainers.image.authors='Stelligent'
+LABEL org.opencontainers.image.licenses='MIT'
+LABEL org.opencontainers.image.source='https://github.com/stelligent/cfn_nag'
+LABEL org.opencontainers.image.title='cfn_nag for development'
+LABEL org.opencontainers.image.vendor='Stelligent'
 
 COPY . /
 
-RUN apk add --update build-base \
-    curl \
-    git
-
-RUN gem install bundler
-RUN gem install rubocop
-RUN bundle install
+RUN apk add --update --no-cache \
+        build-base \
+        curl \
+        git \
+    && gem install \
+        'bundler:2.4.22' \
+        'rubocop:~>1.67' \
+    && bundle install

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,12 @@
+# syntax=docker/dockerfile:1
+
 FROM ruby:2.7-alpine
+
+LABEL org.opencontainers.image.authors='Stelligent'
+LABEL org.opencontainers.image.licenses='MIT'
+LABEL org.opencontainers.image.source='https://github.com/stelligent/cfn_nag'
+LABEL org.opencontainers.image.title='cfn_nag'
+LABEL org.opencontainers.image.vendor='Stelligent'
 
 ARG version
 


### PR DESCRIPTION
The Dockerfile files were updated with the following changes:

* Defined version constraints for `bundler` and `rubocop` in order to fix dependency resolution at `Dockerfile-dev`
  <details>
    <summary>Show dependency resolution issue</summary>
    
    ```
    $ docker build --file Dockerfile-dev --tag cfn_nag:latest .
    [+] Building 136.8s (8/10)                                                                                                                                                                                                     docker:default
     => [internal] load build definition from Dockerfile-dev                                                                                                                                                                                 0.0s
     => => transferring dockerfile: 196B                                                                                                                                                                                                     0.0s
     => [internal] load metadata for docker.io/library/ruby:2.7-alpine                                                                                                                                                                       1.8s
     => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
     => => transferring context: 2B                                                                                                                                                                                                          0.0s
     => [internal] load build context                                                                                                                                                                                                        0.1s
     => => transferring context: 346.58kB                                                                                                                                                                                                    0.1s
     => CACHED [1/6] FROM docker.io/library/ruby:2.7-alpine@sha256:371668748735a808d1fd1c506878e09f40cb542ffc758cfa7eb124f90827e8d9                                                                                                          0.0s
     => [2/6] COPY . /                                                                                                                                                                                                                       0.2s
     => [3/6] RUN apk add --update build-base     curl     git                                                                                                                                                                               8.3s
     => ERROR [4/6] RUN gem install bundler                                                                                                                                                                                                126.2s
    ------                                                                                                                                                                                                                                        
     > [4/6] RUN gem install bundler:                                                                                                                                                                                                             
    126.0 ERROR:  Error installing bundler:                                                                                                                                                                                                       
    126.0   The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`                                                                                                 
    126.0   bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.                                                                                                                                                        
    ------
    Dockerfile-dev:9
    --------------------
       7 |         git
       8 |     
       9 | >>> RUN gem install bundler
      10 |     RUN gem install rubocop
      11 |     RUN bundle install
    --------------------
    ERROR: failed to solve: process "/bin/sh -c gem install bundler" did not complete successfully: exit code: 1
    ```
  </details>
* Combined all the executed commands into a single `RUN` instruction to reduce the number of image layers
* Added `--no-cache` option to `apk add` invocation to reduce image size
* Added the [`syntax` parser directive](https://docs.docker.com/reference/dockerfile/#syntax) to declare the Dockerfile syntax version to use for the build
* Added labels with pre-defined annotation keys from the [OpenContainers Annotations Spec](https://specs.opencontainers.org/image-spec/annotations/#pre-defined-annotation-keys)